### PR TITLE
Running with *no* parameters at all crashes the command line parser

### DIFF
--- a/CommandLineParser.Tests/CustomerReportedTests.cs
+++ b/CommandLineParser.Tests/CustomerReportedTests.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using MatthiWare.CommandLine;
+using Xunit;
+
+namespace MatthiWare.CommandLineParser.Tests
+{
+    public class CustomerReportedTests
+    {
+        /// <summary>
+        /// Running with *no* parameters at all crashes the command line parser #12
+        /// https://github.com/MatthiWare/CommandLineParser.Core/issues/12
+        /// </summary>
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(false, false)]
+        public void NoCommandLineArgumentsCrashesParser_Issue_12(bool required, bool outcome)
+        {
+            var parser = new CommandLineParser<OptionsModelIssue_12>();
+
+            parser.Configure(opt => opt.Test)
+                .Name("-1")
+                .Default(1)
+                .Required(required);
+
+            var parsed = parser.Parse(new[] { "app.exe" });
+
+            Assert.NotNull(parsed);
+
+            Assert.Equal(outcome, parsed.HasErrors);
+        }
+
+        private class OptionsModelIssue_12
+        {
+            public int Test { get; set; }
+        }
+    }
+}

--- a/CommandLineParser/CommandLineParser.csproj
+++ b/CommandLineParser/CommandLineParser.csproj
@@ -1,10 +1,10 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>MatthiWare.CommandLine</RootNamespace>
     <PackageId>MatthiWare.CommandLineParser</PackageId>
-    <Version>0.1.2</Version>
+    <Version>0.1.3</Version>
     <Authors>Matthias Beerens</Authors>
     <Company>MatthiWare</Company>
     <Product>Command Line Parser</Product>

--- a/CommandLineParser/CommandLineParser.nuspec
+++ b/CommandLineParser/CommandLineParser.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>MatthiWare.CommandLineParser</id>
-    <version>0.1.2</version>
+    <version>0.1.3</version>
     <title>CommandLineParser.Core</title>
     <authors>Matthias Beerens</authors>
     <owners>Matthiee</owners>
@@ -10,15 +10,13 @@
     <projectUrl>https://github.com/MatthiWare/CommandLineParser.Core</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>
-      Command Line Parser for .Net Core written in .Net Standard.
-
-      Configuration is done using an option class and/or fluent api.
-      This library allows to add commands with their own set of options as well.
-
-      For sample app and documentation visit: https://github.com/MatthiWare/CommandLineParser.Core
-    </description>
+		Command Line Parser for .Net Core written in .Net Standard.
+		
+		Configuration is done through a option model class using attributes or fluent API can be used to configure the properties of the class. 
+		This library allows to add commands with their own set of options as well. 
+	</description>
 	<summary>A simple, light-weight and strongly typed command line parser. Configuration using fluent API and  an options class. </summary>
-    <releaseNotes>Adds documentation.</releaseNotes>
+    <releaseNotes>Fixed issue where parser would crash when no arguments are supplied.</releaseNotes>
     <copyright>Copyright Matthias Beerens 2018</copyright>
     <tags>commandline parser commandline-parser</tags>
   </metadata>

--- a/CommandLineParser/Core/Parsing/ArgumentManager.cs
+++ b/CommandLineParser/Core/Parsing/ArgumentManager.cs
@@ -51,6 +51,8 @@ namespace MatthiWare.CommandLine.Core.Parsing
             {
                 int idx = FindIndex(item);
 
+                if (idx == -1) continue; // not found issue #12
+
                 SetArgumentUsed(idx, item);
             }
         }
@@ -60,6 +62,8 @@ namespace MatthiWare.CommandLine.Core.Parsing
             foreach (var cmd in cmds)
             {
                 int idx = FindIndex(cmd);
+
+                if (idx == -1) continue;
 
                 SetArgumentUsed(idx, cmd);
 

--- a/SampleApp/SampleApp.csproj
+++ b/SampleApp/SampleApp.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MatthiWare.CommandLineParser" Version="0.1.1" />
+    <PackageReference Include="MatthiWare.CommandLineParser" Version="0.1.3" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Fixes #12 