### PR TITLE
Improve Help Commands

### DIFF
--- a/CommandLineParser.Tests/CommandLineParserTests.cs
+++ b/CommandLineParser.Tests/CommandLineParserTests.cs
@@ -58,7 +58,7 @@ namespace MatthiWare.CommandLineParser.Tests
 
             var parser = new CommandLineParser<AddOption>(argResolverFactory.Object);
 
-            parser.Configure(p => p.Message).Name("-m");
+            parser.Configure(p => p.Message).Name("m");
 
             var result = parser.Parse(new[] { "app.exe", "-m" });
 
@@ -237,6 +237,29 @@ namespace MatthiWare.CommandLineParser.Tests
             Assert.Equal(result1, result.Result.Message);
 
             Assert.True(wait.WaitOne(2000));
+        }
+
+        [Theory]
+        [InlineData(new string[] { "-x", "" }, true)]
+        [InlineData(new string[] { "-x" }, true)]
+        [InlineData(new string[] { "-x", "1" }, true)]
+        [InlineData(new string[] { "-x", "true" }, true)]
+        [InlineData(new string[] { "-x", "false" }, false)]
+        public void BoolResolverSpecialCaseParsesCorrectly(string[] args, bool expected)
+        {
+            var parser = new CommandLineParser<Options>();
+
+            //parser.Configure(opt => opt.Option1)
+            //    .Name("o", "opt")
+            //    .Default("Default message");
+
+            parser.Configure(opt => opt.Option2)
+                .Name("x", "xsomething")
+                .Required();
+
+            var result = parser.Parse(args);
+
+            Assert.Equal(expected, result.Result.Option2);
         }
 
         [Fact]

--- a/CommandLineParser.Tests/Parsing/ParserResultTest.cs
+++ b/CommandLineParser.Tests/Parsing/ParserResultTest.cs
@@ -1,5 +1,6 @@
 ﻿using System;
-
+using System.Collections.Generic;
+using System.Linq;
 using MatthiWare.CommandLine.Abstractions.Parsing.Command;
 using MatthiWare.CommandLine.Core.Parsing;
 
@@ -16,21 +17,19 @@ namespace MatthiWare.CommandLineParser.Tests.Parsing
         {
             var result = new ParseResult<object>();
 
-            Assert.Null(result.Error);
+            Assert.Empty(result.Errors);
 
             var exception1 = new Exception("test");
 
             result.MergeResult(new[] { exception1 });
 
             Assert.True(result.HasErrors);
-            Assert.Same(exception1, result.Error);
+            Assert.Same(exception1, result.Errors.First());
 
             result.MergeResult(new[] { new Exception("2") });
 
             Assert.True(result.HasErrors);
-            Assert.NotSame(exception1, result.Error);
-
-            Assert.IsType<AggregateException>(result.Error);
+            Assert.NotSame(exception1, result.Errors.Skip(1).First());
         }
 
         [Fact]
@@ -41,7 +40,7 @@ namespace MatthiWare.CommandLineParser.Tests.Parsing
             var mockCmdResult = new Mock<ICommandParserResult>();
 
             mockCmdResult.SetupGet(x => x.HasErrors).Returns(false);
-            mockCmdResult.SetupGet(x => x.Error).Returns((Exception)null);
+            mockCmdResult.SetupGet(x => x.Errors).Returns(new List<Exception>());
 
             result.MergeResult(mockCmdResult.Object);
 
@@ -59,7 +58,9 @@ namespace MatthiWare.CommandLineParser.Tests.Parsing
 
             result.MergeResult(obj);
 
-            Assert.Null(result.Error);
+            Assert.False(result.HasErrors);
+
+            Assert.Empty(result.Errors);
 
             Assert.Same(obj, result.Result);
         }

--- a/CommandLineParser.Tests/Parsing/Resolvers/BoolResolverTests.cs
+++ b/CommandLineParser.Tests/Parsing/Resolvers/BoolResolverTests.cs
@@ -11,6 +11,8 @@ namespace MatthiWare.CommandLineParser.Tests.Parsing.Resolvers
         [InlineData("yes")]
         [InlineData("1")]
         [InlineData("true")]
+        [InlineData("")]
+        [InlineData(null)]
         public void TestResolveTrue(string input)
         {
             var resolver = new BoolResolver();

--- a/CommandLineParser.Tests/Usage/HelpDisplayCommandTests.cs
+++ b/CommandLineParser.Tests/Usage/HelpDisplayCommandTests.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using MatthiWare.CommandLine;
+using MatthiWare.CommandLine.Abstractions;
+using MatthiWare.CommandLine.Abstractions.Command;
+using MatthiWare.CommandLine.Abstractions.Usage;
+using MatthiWare.CommandLine.Core.Attributes;
+using Moq;
+using Xunit;
+
+namespace MatthiWare.CommandLineParser.Tests.Usage
+{
+    public class HelpDisplayCommandTests
+    {
+        [Theory]
+        [InlineData(new string[] { "db", "--help" }, true)]
+        [InlineData(new string[] { "db" }, true)]
+        [InlineData(new string[] { "db", "-o", "--help" }, true)]
+        [InlineData(new string[] { "db", "-o", "help" }, false)]
+        [InlineData(new string[] { "-x", "blabla", "--help" }, true)]
+        [InlineData(new string[] { }, true)]
+        [InlineData(new string[] { "-x", "--help" }, true)]
+        [InlineData(new string[] { "--help" }, true)]
+        public void TestHelpDisplayFiresCorrectly(string[] args, bool fires)
+        {
+            bool calledFlag = false;
+
+            var usagePrinterMock = new Mock<IUsagePrinter>();
+
+            usagePrinterMock.Setup(mock => mock.PrintUsage()).Callback(() => calledFlag = true);
+            usagePrinterMock.Setup(mock => mock.PrintUsage(It.IsAny<ICommandLineCommand>())).Callback(() => calledFlag = true);
+            usagePrinterMock.Setup(mock => mock.PrintUsage(It.IsAny<ICommandLineOption>())).Callback(() => calledFlag = true);
+
+            var parser = new CommandLineParser<Options>
+            {
+                Printer = usagePrinterMock.Object
+            };
+
+            var cmd = parser.AddCommand<CommandOptions>()
+                .Name("db")
+                .Description("Database commands");
+
+            parser.Parse(args);
+
+            Assert.Equal<bool>(fires, calledFlag);
+        }
+
+        public class Options
+        {
+            [Name("x"), Description("Some description")]
+            public string Option { get; set; }
+        }
+
+        public class CommandOptions
+        {
+            [Name("o"), Description("Some description"), Required]
+            public string Option { get; set; }
+        }
+    }
+}

--- a/CommandLineParser.Tests/Usage/UsagePrinterTests.cs
+++ b/CommandLineParser.Tests/Usage/UsagePrinterTests.cs
@@ -1,4 +1,6 @@
 ﻿using MatthiWare.CommandLine;
+using MatthiWare.CommandLine.Abstractions;
+using MatthiWare.CommandLine.Abstractions.Command;
 using MatthiWare.CommandLine.Abstractions.Usage;
 using MatthiWare.CommandLine.Core.Attributes;
 using Moq;
@@ -11,6 +13,12 @@ namespace MatthiWare.CommandLineParser.Tests.Usage
         private class UsagePrinterGetsCalledOptions
         {
             [Name("o"), Required]
+            public string Option { get; set; }
+        }
+
+        private class UsagePrinterCommandOptions
+        {
+            [Name("x"), Required]
             public string Option { get; set; }
         }
 
@@ -30,6 +38,40 @@ namespace MatthiWare.CommandLineParser.Tests.Usage
             parser.Parse(args);
 
             printerMock.Verify(mock => mock.PrintUsage(), called ? Times.Once() : Times.Never());
+        }
+
+        [Fact]
+        public void UsagePrinterPrintsOptionCorrectly()
+        {
+            var printerMock = new Mock<IUsagePrinter>();
+
+            var parser = new CommandLineParser<UsagePrinterGetsCalledOptions>
+            {
+                Printer = printerMock.Object
+            };
+
+            parser.Parse(new[] { "-o", "--help" });
+
+            printerMock.Verify(mock => mock.PrintUsage(It.IsAny<ICommandLineOption>()), Times.Once());
+        }
+
+        [Fact]
+        public void UsagePrinterPrintsCommandCorrectly()
+        {
+            var printerMock = new Mock<IUsagePrinter>();
+
+            var parser = new CommandLineParser<UsagePrinterGetsCalledOptions>
+            {
+                Printer = printerMock.Object
+            };
+
+            parser.AddCommand<UsagePrinterCommandOptions>()
+                .Name("cmd")
+                .Required();
+
+            parser.Parse(new[] { "-o", "bla", "cmd", "--help" });
+
+            printerMock.Verify(mock => mock.PrintUsage(It.IsAny<ICommandLineCommand>()), Times.Once());
         }
     }
 }

--- a/CommandLineParser/Abstractions/IArgument.cs
+++ b/CommandLineParser/Abstractions/IArgument.cs
@@ -5,7 +5,7 @@ namespace MatthiWare.CommandLine.Abstractions
 {
     /// <summary>
     /// Represents an argument
-    /// <see cref="ArgumentModel"/>, <see cref="ICommandLineOption"/> and <see cref="ICommandLineCommand"/> for more info.
+    /// See <see cref="ICommandLineOption"/> and <see cref="ICommandLineCommand"/> for more info.
     /// </summary>
     public interface IArgument { }
 }

--- a/CommandLineParser/Abstractions/Models/ArgumentModel.cs
+++ b/CommandLineParser/Abstractions/Models/ArgumentModel.cs
@@ -1,8 +1,11 @@
-﻿namespace MatthiWare.CommandLine.Abstractions.Models
+﻿using System.Diagnostics;
+
+namespace MatthiWare.CommandLine.Abstractions.Models
 {
     /// <summary>
     /// Model for command line arguments
     /// </summary>
+    [DebuggerDisplay("Argument key: {Key} value: {Value}")]
     public struct ArgumentModel
     {
         /// <summary>

--- a/CommandLineParser/Abstractions/Parsing/Command/ICommandParserResult.cs
+++ b/CommandLineParser/Abstractions/Parsing/Command/ICommandParserResult.cs
@@ -11,6 +11,11 @@ namespace MatthiWare.CommandLine.Abstractions.Parsing.Command
     public interface ICommandParserResult
     {
         /// <summary>
+        /// Returns true if the user specified a help option
+        /// </summary>
+        bool HelpRequested { get; }
+
+        /// <summary>
         /// Subcommands of the current command
         /// </summary>
         IReadOnlyCollection<ICommandParserResult> SubCommands { get; }

--- a/CommandLineParser/Abstractions/Parsing/Command/ICommandParserResult.cs
+++ b/CommandLineParser/Abstractions/Parsing/Command/ICommandParserResult.cs
@@ -10,6 +10,8 @@ namespace MatthiWare.CommandLine.Abstractions.Parsing.Command
     /// </summary>
     public interface ICommandParserResult
     {
+        IArgument HelpRequestedFor { get; }
+
         /// <summary>
         /// Returns true if the user specified a help option
         /// </summary>
@@ -31,15 +33,15 @@ namespace MatthiWare.CommandLine.Abstractions.Parsing.Command
         bool HasErrors { get; }
 
         /// <summary>
-        /// Contains the thrown exception during parsing.
+        /// Contains the thrown exception(s) during parsing.
         /// </summary>
-        Exception Error { get; }
+        IReadOnlyCollection<Exception> Errors { get; }
 
         /// <summary>
         /// Executes the command
         /// </summary>
         /// <exception cref="InvalidOperationException">
-        /// Result contains exceptions. For more info see <see cref="HasErrors"/> and <see cref="Error"/> properties.
+        /// Result contains exceptions. For more info see <see cref="HasErrors"/> and <see cref="Errors"/> properties.
         /// </exception>
         void ExecuteCommand();
     }

--- a/CommandLineParser/Abstractions/Parsing/IParserResult.cs
+++ b/CommandLineParser/Abstractions/Parsing/IParserResult.cs
@@ -12,11 +12,13 @@ namespace MatthiWare.CommandLine.Abstractions.Parsing
         /// </summary>
         bool HelpRequested { get; }
 
+        IArgument HelpRequestedFor { get; }
+
         /// <summary>
         /// Parsed result
         /// </summary>
         /// <exception cref="InvalidOperationException">
-        /// Result contains exceptions. For more info see <see cref="HasErrors"/> and <see cref="Error"/> properties.
+        /// Result contains exceptions. For more info see <see cref="HasErrors"/> and <see cref="Errors"/> properties.
         /// </exception>
         TResult Result { get; }
 
@@ -28,13 +30,13 @@ namespace MatthiWare.CommandLine.Abstractions.Parsing
         /// <summary>
         /// Contains the thrown exception during parsing.
         /// </summary>
-        Exception Error { get; }
+        IReadOnlyCollection<Exception> Errors { get; }
 
         /// <summary>
         /// Executes the commands
         /// </summary>
         /// /// <exception cref="InvalidOperationException">
-        /// Result contains exceptions. For more info see <see cref="HasErrors"/> and <see cref="Error"/> properties.
+        /// Result contains exceptions. For more info see <see cref="HasErrors"/> and <see cref="Errors"/> properties.
         /// </exception>
         void ExecuteCommands();
 

--- a/CommandLineParser/Abstractions/Parsing/IParserResult.cs
+++ b/CommandLineParser/Abstractions/Parsing/IParserResult.cs
@@ -8,6 +8,11 @@ namespace MatthiWare.CommandLine.Abstractions.Parsing
     public interface IParserResult<TResult>
     {
         /// <summary>
+        /// Returns true if the user specified a help option
+        /// </summary>
+        bool HelpRequested { get; }
+
+        /// <summary>
         /// Parsed result
         /// </summary>
         /// <exception cref="InvalidOperationException">

--- a/CommandLineParser/Abstractions/Usage/IUsagePrinter.cs
+++ b/CommandLineParser/Abstractions/Usage/IUsagePrinter.cs
@@ -6,5 +6,6 @@ namespace MatthiWare.CommandLine.Abstractions.Usage
     {
         void PrintUsage();
         void PrintUsage(ICommandLineCommand command);
+        void PrintUsage(ICommandLineOption option);
     }
 }

--- a/CommandLineParser/CommandLineParser.cs
+++ b/CommandLineParser/CommandLineParser.cs
@@ -181,7 +181,7 @@ namespace MatthiWare.CommandLine
 
             var result = new ParseResult<TOption>();
 
-            var argumentManager = new ArgumentManager(args, m_commands, m_options.Values);
+            var argumentManager = new ArgumentManager(args, m_parserOptions.EnableHelpOption, m_helpOptionName, m_helpOptionNameLong, m_commands, m_options.Values);
 
             ParseCommands(errors, result, argumentManager);
 
@@ -316,15 +316,15 @@ namespace MatthiWare.CommandLine
                 var option = o.Value;
                 bool found = argumentManager.TryGetValue(option, out ArgumentModel model);
 
-                if (!found && option.IsRequired)
+                if (found && HelpRequested(result, option, model))
+                {
+                    break;
+                }
+                else if (!found && option.IsRequired)
                 {
                     errors.Add(new OptionNotFoundException(m_parserOptions, option));
 
                     continue;
-                }
-                else if (found && HelpRequested(result, option, model))
-                {
-                    break;
                 }
                 else if (!model.HasValue && option.HasDefault)
                 {

--- a/CommandLineParser/CommandLineParser.cs
+++ b/CommandLineParser/CommandLineParser.cs
@@ -28,13 +28,15 @@ namespace MatthiWare.CommandLine
     /// Command line parser
     /// </summary>
     /// <typeparam name="TOption">Options model</typeparam>
-    public sealed class CommandLineParser<TOption> : ICommandLineParser<TOption>, ICommandLineCommandContainer
+    public sealed class CommandLineParser<TOption> : ICommandLineParser<TOption>, ICommandLineCommandContainer, IArgument
         where TOption : class, new()
     {
         private readonly TOption m_option;
         private readonly Dictionary<string, CommandLineOptionBase> m_options;
         private readonly List<CommandLineCommandBase> m_commands;
         private readonly CommandLineParserOptions m_parserOptions;
+        private readonly string m_helpOptionName;
+        private readonly string m_helpOptionNameLong;
 
         /// <summary>
         /// Tool to print usage info.
@@ -123,6 +125,22 @@ namespace MatthiWare.CommandLine
 
             Printer = new UsagePrinter(m_parserOptions, this);
 
+            if (m_parserOptions.EnableHelpOption)
+            {
+                var tokens = m_parserOptions.HelpOptionName.Split('|');
+
+                if (tokens.Length > 1)
+                {
+                    m_helpOptionName = $"{m_parserOptions.PrefixShortOption}{tokens[0]}";
+                    m_helpOptionNameLong = $"{m_parserOptions.PrefixLongOption}{tokens[1]}";
+                }
+                else
+                {
+                    m_helpOptionName = $"{m_parserOptions.PrefixLongOption}{tokens[0]}";
+                    m_helpOptionNameLong = null;
+                }
+            }
+
             InitialzeModel();
         }
 
@@ -169,41 +187,94 @@ namespace MatthiWare.CommandLine
 
             ParseOptions(errors, result, argumentManager);
 
+            CheckForExtraHelpArguments(result, argumentManager);
+
             result.MergeResult(errors);
 
             AutoExecuteCommands(result);
 
-            AutoPrintUsageAndErrors(errors, args.Length > 0);
+            AutoPrintUsageAndErrors(result, args.Length == 0);
 
             return result;
         }
 
-        private void AutoPrintUsageAndErrors(ICollection<Exception> errors, bool argsSuppplied)
+        private void CheckForExtraHelpArguments(ParseResult<TOption> result, ArgumentManager argumentManager)
+        {
+            var unusedArg = argumentManager.UnusedArguments
+                .Where(a => string.Equals(a.Argument, m_helpOptionName, StringComparison.InvariantCultureIgnoreCase) ||
+                string.Equals(a.Argument, m_helpOptionNameLong, StringComparison.InvariantCultureIgnoreCase))
+                .FirstOrDefault();
+
+            if (unusedArg == null) return;
+
+            result.HelpRequestedFor = unusedArg.ArgModel ?? this;
+        }
+
+        private void AutoPrintUsageAndErrors(ParseResult<TOption> result, bool noArgsSupplied)
         {
             if (!m_parserOptions.AutoPrintUsageAndErrors) return;
 
-            if (!argsSuppplied)
+            if (noArgsSupplied)
                 PrintHelp();
-            else if (errors.Count > 0)
-                PrintErrors(errors);
+            else if (result.HelpRequested)
+                PrintHelpFor(result.HelpRequestedFor);
+            else if (result.HasErrors)
+                PrintErrors(result.Errors);
         }
 
-        private void PrintErrors(ICollection<Exception> errors)
+        private void PrintHelpFor(IArgument helpRequestedFor)
         {
+            switch (helpRequestedFor)
+            {
+                case ICommandLineCommand cmd:
+                    Printer.PrintUsage(cmd);
+                    break;
+                case ICommandLineOption opt:
+                    Printer.PrintUsage(opt);
+                    break;
+                default:
+                    PrintHelp();
+                    break;
+            }
+        }
+
+        private void PrintErrors(IReadOnlyCollection<Exception> errors)
+        {
+            var previousColor = Console.ForegroundColor;
+
+            Console.ForegroundColor = ConsoleColor.DarkRed;
+
             foreach (var error in errors)
                 Console.Error.WriteLine(error.Message);
+
+            Console.ForegroundColor = previousColor;
 
             PrintHelp();
         }
 
-        private void PrintHelp()
-            => Printer.PrintUsage();
+        private void PrintHelp() => Printer.PrintUsage();
 
         private void AutoExecuteCommands(IParserResult<TOption> result)
         {
             if (result.HasErrors) return;
 
             ExecuteCommandParserResults(result.CommandResults.Where(r => r.Command.AutoExecute));
+        }
+
+        private bool HelpRequested(ParseResult<TOption> result, CommandLineOptionBase option, ArgumentModel model)
+        {
+            if (!m_parserOptions.EnableHelpOption) return false;
+
+            if (model.HasValue &&
+              (model.Value.Equals(m_helpOptionName, StringComparison.InvariantCultureIgnoreCase) ||
+              model.Value.Equals(m_helpOptionNameLong, StringComparison.InvariantCultureIgnoreCase)))
+            {
+                result.HelpRequestedFor = option;
+
+                return true;
+            }
+
+            return false;
         }
 
         private void ExecuteCommandParserResults(IEnumerable<ICommandParserResult> results)
@@ -229,9 +300,12 @@ namespace MatthiWare.CommandLine
                 var cmdParseResult = cmd.Parse(argumentManager);
 
                 if (cmdParseResult.HasErrors)
-                    errors.Add(new CommandParseException(cmd, cmdParseResult.Error));
+                    errors.Add(new CommandParseException(cmd, cmdParseResult.Errors));
 
                 result.MergeResult(cmdParseResult);
+
+                if (result.HelpRequested)
+                    break;
             }
         }
 
@@ -240,12 +314,17 @@ namespace MatthiWare.CommandLine
             foreach (var o in m_options)
             {
                 var option = o.Value;
+                bool found = argumentManager.TryGetValue(option, out ArgumentModel model);
 
-                if (!argumentManager.TryGetValue(option, out ArgumentModel model) && option.IsRequired)
+                if (!found && option.IsRequired)
                 {
                     errors.Add(new OptionNotFoundException(m_parserOptions, option));
 
                     continue;
+                }
+                else if (found && HelpRequested(result, option, model))
+                {
+                    break;
                 }
                 else if (!model.HasValue && option.HasDefault)
                 {

--- a/CommandLineParser/CommandLineParser.nuspec
+++ b/CommandLineParser/CommandLineParser.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>MatthiWare.CommandLineParser</id>
-    <version>0.2.0-alpha</version>
+    <version>0.2.0</version>
     <title>CommandLineParser.Core</title>
     <authors>Matthias Beerens</authors>
     <owners>Matthiee</owners>
@@ -16,7 +16,7 @@
 		This library allows to add commands with their own set of options as well. 
 	</description>
 	<summary>A simple, light-weight and strongly typed command line parser. Configuration using fluent API and  an options class. </summary>
-    <releaseNotes>New set of command features are added, support for DI/IoC.</releaseNotes>
+    <releaseNotes>Improvements for help commands and general bugfixes.</releaseNotes>
     <copyright>Copyright Matthias Beerens 2018</copyright>
     <tags>commandline parser commandline-parser</tags>
   </metadata>

--- a/CommandLineParser/CommandLineParserOptions.cs
+++ b/CommandLineParser/CommandLineParserOptions.cs
@@ -1,9 +1,19 @@
-﻿namespace MatthiWare.CommandLine
+﻿using System.Diagnostics;
+
+namespace MatthiWare.CommandLine
 {
     public class CommandLineParserOptions
     {
+        /// <summary>
+        /// Prefix for the short option
+        /// </summary>
         public string PrefixShortOption { get; set; } = "-";
+
+        /// <summary>
+        /// Prefix for the long option
+        /// </summary>
         public string PrefixLongOption { get; set; } = "--";
+
         /// <summary>
         /// Help option name. 
         /// Accepts both formatted and unformatted help name. 
@@ -11,8 +21,21 @@
         /// If the name is split for example h|help it will use the following format <![CDATA[<shortOption>|<longOption>]]>
         /// </summary>
         public string HelpOptionName { get; set; } = "h|help";
+
+        /// <summary>
+        /// Enable or disable the help option
+        /// <see cref="HelpOptionName"/>
+        /// </summary>
         public bool EnableHelpOption { get; set; } = true;
+
+        /// <summary>
+        /// Enables or disables the automatic usage and error printing
+        /// </summary>
         public bool AutoPrintUsageAndErrors { get; set; } = true;
+
+        /// <summary>
+        /// Sets the application name. Will use the <see cref="Process.ProcessName"/> by default if none is specified.
+        /// </summary>
         public string AppName { get; set; }
     }
 }

--- a/CommandLineParser/Core/Command/CommandLineCommandBase.cs
+++ b/CommandLineParser/Core/Command/CommandLineCommandBase.cs
@@ -1,13 +1,13 @@
 ﻿using System.Collections.Generic;
-using System.Text;
+using System.Diagnostics;
 using MatthiWare.CommandLine.Abstractions;
 using MatthiWare.CommandLine.Abstractions.Command;
 using MatthiWare.CommandLine.Abstractions.Parsing;
 using MatthiWare.CommandLine.Abstractions.Parsing.Command;
-using MatthiWare.CommandLine.Abstractions.Usage;
 
 namespace MatthiWare.CommandLine.Core.Command
 {
+    [DebuggerDisplay("Command [{Name}] Options: {m_options.Count} Commands: {m_commands.Count} Required: {IsRequired} Execute: {AutoExecute}")]
     internal abstract class CommandLineCommandBase :
         ICommandLineCommandParser,
         ICommandLineCommandContainer,

--- a/CommandLineParser/Core/Command/CommandLineCommand`TOption`TCommandOption.cs
+++ b/CommandLineParser/Core/Command/CommandLineCommand`TOption`TCommandOption.cs
@@ -34,6 +34,10 @@ namespace MatthiWare.CommandLine.Core.Command
         private Action<TOption> m_executor1;
         private Action<TOption, TCommandOption> m_executor2;
 
+        private readonly string m_helpOptionName;
+        private readonly string m_helpOptionNameLong;
+
+
         public CommandLineCommand(CommandLineParserOptions parserOptions, IArgumentResolverFactory resolverFactory, IContainerResolver containerResolver, TOption option)
         {
             m_parserOptions = parserOptions;
@@ -42,6 +46,22 @@ namespace MatthiWare.CommandLine.Core.Command
             m_containerResolver = containerResolver;
             m_resolverFactory = resolverFactory;
             m_baseOption = option;
+
+            if (m_parserOptions.EnableHelpOption)
+            {
+                var tokens = m_parserOptions.HelpOptionName.Split('|');
+
+                if (tokens.Length > 1)
+                {
+                    m_helpOptionName = $"{m_parserOptions.PrefixShortOption}{tokens[0]}";
+                    m_helpOptionNameLong = $"{m_parserOptions.PrefixLongOption}{tokens[1]}";
+                }
+                else
+                {
+                    m_helpOptionName = $"{m_parserOptions.PrefixLongOption}{tokens[0]}";
+                    m_helpOptionNameLong = null;
+                }
+            }
 
             InitialzeModel();
         }
@@ -89,8 +109,11 @@ namespace MatthiWare.CommandLine.Core.Command
 
                 var cmdParseResult = cmd.Parse(argumentManager);
 
+                if (cmdParseResult.HelpRequested)
+                    return result;
+
                 if (cmdParseResult.HasErrors)
-                    errors.Add(new CommandParseException(cmd, cmdParseResult.Error));
+                    errors.Add(new CommandParseException(cmd, cmdParseResult.Errors));
 
                 result.MergeResult(cmdParseResult);
             }
@@ -98,12 +121,17 @@ namespace MatthiWare.CommandLine.Core.Command
             foreach (var o in m_options)
             {
                 var option = o.Value;
+                bool found = argumentManager.TryGetValue(option, out ArgumentModel model);
 
-                if (!argumentManager.TryGetValue(option, out ArgumentModel model) && option.IsRequired)
+                if (!found && option.IsRequired)
                 {
                     errors.Add(new OptionNotFoundException(m_parserOptions, option));
 
                     continue;
+                }
+                else if (found && HelpRequested(result, option, model))
+                {
+                    break;
                 }
                 else if (!model.HasValue && option.HasDefault)
                 {
@@ -124,6 +152,29 @@ namespace MatthiWare.CommandLine.Core.Command
             result.MergeResult(errors);
 
             return result;
+        }
+
+        private bool HelpRequested(CommandParserResult result, CommandLineOptionBase option, ArgumentModel model)
+        {
+            if (!m_parserOptions.EnableHelpOption) return false;
+
+            if (model.Key.Equals(m_helpOptionName, StringComparison.InvariantCultureIgnoreCase) ||
+                model.Key.Equals(m_helpOptionNameLong, StringComparison.InvariantCultureIgnoreCase))
+            {
+                result.HelpRequestedFor = this;
+
+                return true;
+            }
+            else if (model.HasValue &&
+              (model.Value.Equals(m_helpOptionName, StringComparison.InvariantCultureIgnoreCase) ||
+              model.Value.Equals(m_helpOptionNameLong, StringComparison.InvariantCultureIgnoreCase)))
+            {
+                result.HelpRequestedFor = option;
+
+                return true;
+            }
+
+            return false;
         }
 
         public ICommandBuilder<TOption, TCommandOption> Required(bool required = true)

--- a/CommandLineParser/Core/Command/CommandLineCommand`TOption`TCommandOption.cs
+++ b/CommandLineParser/Core/Command/CommandLineCommand`TOption`TCommandOption.cs
@@ -123,15 +123,15 @@ namespace MatthiWare.CommandLine.Core.Command
                 var option = o.Value;
                 bool found = argumentManager.TryGetValue(option, out ArgumentModel model);
 
-                if (!found && option.IsRequired)
+                if (found && HelpRequested(result, option, model))
+                {
+                    break;
+                }
+                else if (!found && option.IsRequired)
                 {
                     errors.Add(new OptionNotFoundException(m_parserOptions, option));
 
                     continue;
-                }
-                else if (found && HelpRequested(result, option, model))
-                {
-                    break;
                 }
                 else if (!model.HasValue && option.HasDefault)
                 {

--- a/CommandLineParser/Core/Command/CommandParserResult.cs
+++ b/CommandLineParser/Core/Command/CommandParserResult.cs
@@ -12,13 +12,15 @@ namespace MatthiWare.CommandLine.Core.Command
         private readonly CommandLineCommandBase m_cmd;
         private readonly List<ICommandParserResult> commandParserResults = new List<ICommandParserResult>();
 
-        public bool HasErrors { get; private set; }
+        public bool HasErrors { get; private set; } = false;
 
         public Exception Error { get; private set; } = null;
 
         public ICommandLineCommand Command => m_cmd;
 
         public IReadOnlyCollection<ICommandParserResult> SubCommands => commandParserResults;
+
+        public bool HelpRequested { get; set; } = false;
 
         public CommandParserResult(CommandLineCommandBase command)
         {

--- a/CommandLineParser/Core/Exceptions/CommandParseException.cs
+++ b/CommandLineParser/Core/Exceptions/CommandParseException.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-
+using System.Collections.Generic;
 using MatthiWare.CommandLine.Abstractions.Command;
 
 namespace MatthiWare.CommandLine.Core.Exceptions
@@ -14,8 +14,8 @@ namespace MatthiWare.CommandLine.Core.Exceptions
         /// </summary>
         public ICommandLineCommand Command { get; set; }
 
-        public CommandParseException(ICommandLineCommand command, Exception innerException)
-            : base("", innerException)
+        public CommandParseException(ICommandLineCommand command, IReadOnlyCollection<Exception> innerExceptions)
+            : base("", new AggregateException(innerExceptions))
         {
             Command = command;
         }

--- a/CommandLineParser/Core/Parsing/ArgumentManager.cs
+++ b/CommandLineParser/Core/Parsing/ArgumentManager.cs
@@ -16,6 +16,8 @@ namespace MatthiWare.CommandLine.Core.Parsing
         private readonly IDictionary<IArgument, ArgumentModel> resultCache;
         private readonly List<ArgumentValueHolder> args;
 
+        public IQueryable<ArgumentValueHolder> UnusedArguments => args.AsQueryable().Where(a => !a.Used);
+
         public ArgumentManager(string[] args, ICollection<CommandLineCommandBase> commands, ICollection<CommandLineOptionBase> options)
         {
             resultCache = new Dictionary<IArgument, ArgumentModel>(commands.Count + options.Count);
@@ -77,6 +79,8 @@ namespace MatthiWare.CommandLine.Core.Parsing
                     // find the option index starting at the command index
                     int optionIdx = FindIndex(option, idx);
 
+                    if (optionIdx == -1) continue;
+
                     SetArgumentUsed(optionIdx, option);
                 }
 
@@ -122,7 +126,7 @@ namespace MatthiWare.CommandLine.Core.Parsing
         public bool TryGetValue(IArgument argument, out ArgumentModel model) => resultCache.TryGetValue(argument, out model);
 
         [DebuggerDisplay("{Argument}, used: {Used}, index: {Index}")]
-        private class ArgumentValueHolder
+        public class ArgumentValueHolder
         {
             public string Argument { get; set; }
             public bool Used { get; set; }

--- a/CommandLineParser/Core/Parsing/ParseResult'.cs
+++ b/CommandLineParser/Core/Parsing/ParseResult'.cs
@@ -32,6 +32,8 @@ namespace MatthiWare.CommandLine.Core.Parsing
 
         public IReadOnlyList<ICommandParserResult> CommandResults => commandParserResults.AsReadOnly();
 
+        public bool HelpRequested { get; set; } = false;
+
         #endregion
 
         public void MergeResult(ICommandParserResult result)

--- a/CommandLineParser/Core/Parsing/ParseResult'.cs
+++ b/CommandLineParser/Core/Parsing/ParseResult'.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-
+using MatthiWare.CommandLine.Abstractions;
 using MatthiWare.CommandLine.Abstractions.Parsing;
 using MatthiWare.CommandLine.Abstractions.Parsing.Command;
 
@@ -10,7 +10,7 @@ namespace MatthiWare.CommandLine.Core.Parsing
     internal class ParseResult<TResult> : IParserResult<TResult>
     {
         private readonly List<ICommandParserResult> commandParserResults = new List<ICommandParserResult>();
-        private readonly ICollection<Exception> exceptions = new List<Exception>();
+        private readonly List<Exception> exceptions = new List<Exception>();
 
         #region Properties
 
@@ -18,27 +18,22 @@ namespace MatthiWare.CommandLine.Core.Parsing
 
         public bool HasErrors { get; private set; } = false;
 
-        public Exception Error
-        {
-            get
-            {
-                if (!HasErrors) return null;
-
-                return (exceptions.Count > 1) ?
-                    new AggregateException(exceptions) :
-                    exceptions.First();
-            }
-        }
-
         public IReadOnlyList<ICommandParserResult> CommandResults => commandParserResults.AsReadOnly();
 
-        public bool HelpRequested { get; set; } = false;
+        public bool HelpRequested => HelpRequestedFor != null;
+
+        public IArgument HelpRequestedFor { get; set; } = null;
+
+        public IReadOnlyCollection<Exception> Errors => exceptions;
 
         #endregion
 
         public void MergeResult(ICommandParserResult result)
         {
             HasErrors |= result.HasErrors;
+
+            if (result.HelpRequested)
+                HelpRequestedFor = result.HelpRequestedFor;
 
             commandParserResults.Add(result);
         }
@@ -49,8 +44,7 @@ namespace MatthiWare.CommandLine.Core.Parsing
 
             HasErrors = true;
 
-            foreach (var err in errors)
-                exceptions.Add(err);
+            exceptions.AddRange(errors);
         }
 
         public void MergeResult(TResult result)

--- a/CommandLineParser/Core/Parsing/Resolvers/BoolResolver.cs
+++ b/CommandLineParser/Core/Parsing/Resolvers/BoolResolver.cs
@@ -9,7 +9,7 @@ namespace MatthiWare.CommandLine.Core.Parsing.Resolvers
     internal class BoolResolver : ArgumentResolver<bool>
     {
         private static readonly string[] recognisedFalseArgs = new[] { "off", "0", "false", "no" };
-        private static readonly string[] recognisedTrueArgs = new[] { "on", "1", "true", "yes" };
+        private static readonly string[] recognisedTrueArgs = new[] { "on", "1", "true", "yes", string.Empty, null };
 
         public override bool CanResolve(ArgumentModel model) => TryParse(model, out _);
 
@@ -22,12 +22,6 @@ namespace MatthiWare.CommandLine.Core.Parsing.Resolvers
 
         private bool TryParse(ArgumentModel model, out bool result)
         {
-            if (!model.HasValue)
-            {
-                result = false;
-                return false;
-            }
-
             if (recognisedFalseArgs.Contains(model.Value, StringComparer.InvariantCultureIgnoreCase))
             {
                 result = false;

--- a/CommandLineParser/Core/Usage/UsagePrinter.cs
+++ b/CommandLineParser/Core/Usage/UsagePrinter.cs
@@ -29,5 +29,11 @@ namespace MatthiWare.CommandLine.Core.Usage
             m_usageBuilder.PrintCommand(command.Name, (ICommandLineCommandContainer)command);
             m_usageBuilder.Print();
         }
+
+        public void PrintUsage(ICommandLineOption option)
+        {
+            m_usageBuilder.PrintOption(option);
+            m_usageBuilder.Print();
+        }
     }
 }

--- a/SampleApp/Program.cs
+++ b/SampleApp/Program.cs
@@ -47,6 +47,10 @@ namespace SampleApp
 
             if (result.HasErrors)
             {
+                // note that errors will be automatically printed if `CommandLineParserOptions.AutoPrintUsageAndErrors` is set to true.
+                foreach (var exception in result.Errors)
+                    HandleException(exception);
+
                 Console.ReadKey();
 
                 return -1;
@@ -62,6 +66,11 @@ namespace SampleApp
             Console.ReadKey();
 
             return 0;
+        }
+
+        private static void HandleException(Exception exception)
+        {
+            // Do something with the exception..
         }
 
         private class Options


### PR DESCRIPTION
Improves the help command and help command printer. 

Example:

| cmd | print | 
| ----- | ----- |
| app | print full help |
| app --option --help | print option help |
| app --option (only in required option) | print option help |
| app db | print cmd option |
| app db --help | print cmd option |

