### PR TITLE
Usage output fixed

### DIFF
--- a/CommandLineParser/Abstractions/Usage/IUsageBuilder.cs
+++ b/CommandLineParser/Abstractions/Usage/IUsageBuilder.cs
@@ -8,7 +8,7 @@ namespace MatthiWare.CommandLine.Abstractions.Usage
         void Print();
         void PrintUsage(string name, bool hasOptions, bool hasCommands);
         void PrintOptions(IEnumerable<ICommandLineOption> options, int descriptionShift = 4);
-        void PrintOption(ICommandLineOption option, int descriptionShift = 4);
+        void PrintOption(ICommandLineOption option, int descriptionShift = 4, bool compensateSeparator = false);
         void PrintCommandDescriptions(IEnumerable<ICommandLineCommand> commands, int descriptionShift = 4);
         void PrintCommandDescription(ICommandLineCommand command, int descriptionShift = 4);
         void PrintCommand(string name, ICommandLineCommandContainer container);

--- a/CommandLineParser/Abstractions/Usage/IUsageBuilder.cs
+++ b/CommandLineParser/Abstractions/Usage/IUsageBuilder.cs
@@ -7,10 +7,10 @@ namespace MatthiWare.CommandLine.Abstractions.Usage
     {
         void Print();
         void PrintUsage(string name, bool hasOptions, bool hasCommands);
-        void PrintOptions(IEnumerable<ICommandLineOption> options);
-        void PrintOption(ICommandLineOption option);
-        void PrintCommandDescriptions(IEnumerable<ICommandLineCommand> commands);
-        void PrintCommandDescription(ICommandLineCommand command);
+        void PrintOptions(IEnumerable<ICommandLineOption> options, int descriptionShift = 4);
+        void PrintOption(ICommandLineOption option, int descriptionShift = 4);
+        void PrintCommandDescriptions(IEnumerable<ICommandLineCommand> commands, int descriptionShift = 4);
+        void PrintCommandDescription(ICommandLineCommand command, int descriptionShift = 4);
         void PrintCommand(string name, ICommandLineCommandContainer container);
     }
 }

--- a/CommandLineParser/Core/Usage/UsageBuilder.cs
+++ b/CommandLineParser/Core/Usage/UsageBuilder.cs
@@ -46,40 +46,43 @@ namespace MatthiWare.CommandLine.Core.Usage
             PrintCommandDescriptions(container.Commands);
         }
 
-        public void PrintCommandDescription(ICommandLineCommand command)
-            => stringBuilder.AppendLine($"  {command.Name}\t\t{command.Description}");
+        public void PrintCommandDescription(ICommandLineCommand command, int descriptionShift = 4)
+            => stringBuilder.AppendLine($"  {command.Name}{new string(' ', descriptionShift)}{command.Description}");
 
-        public void PrintCommandDescriptions(IEnumerable<ICommandLineCommand> commands)
+        public void PrintCommandDescriptions(IEnumerable<ICommandLineCommand> commands, int descriptionShift = 4)
         {
             if (!commands.Any()) return;
 
             stringBuilder.AppendLine().AppendLine("Commands: ");
 
+            var longestCommandName = commands.Max(x => x.Name.Length);
             foreach (var cmd in commands)
-                PrintCommandDescription(cmd);
+                PrintCommandDescription(cmd, longestCommandName - cmd.Name.Length + descriptionShift);
         }
 
-        public void PrintOption(ICommandLineOption option)
+        public void PrintOption(ICommandLineOption option, int descriptionShift = 4)
         {
             bool hasShort = option.HasShortName;
             bool hasLong = option.HasLongName;
             bool hasBoth = hasShort && hasLong;
 
-            string hasBothSeperator = hasBoth ? "|" : string.Empty;
+            string hasBothSeparator = hasBoth ? "|" : string.Empty;
             string shortName = hasShort ? option.ShortName : string.Empty;
             string longName = hasLong ? option.LongName : string.Empty;
 
-            stringBuilder.AppendLine($"  {shortName}{hasBothSeperator}{longName}\t{option.Description}");
+            stringBuilder.AppendLine($"  {shortName}{hasBothSeparator}{longName}{new string(' ', descriptionShift)}{option.Description}");
         }
 
-        public void PrintOptions(IEnumerable<ICommandLineOption> options)
+        public void PrintOptions(IEnumerable<ICommandLineOption> options, int descriptionShift = 4)
         {
             if (!options.Any()) return;
 
             stringBuilder.AppendLine().AppendLine("Options: ");
 
+            var longestOptionName = options.Max(x => x.ShortName.Length + x.LongName.Length);
+            var separatorCompensation = options.Any(x => x.HasShortName && x.HasLongName) ? 1 : 0;
             foreach (var opt in options)
-                PrintOption(opt);
+                PrintOption(opt, longestOptionName - opt.LongName.Length - opt.ShortName.Length + separatorCompensation + descriptionShift);
         }
     }
 }

--- a/CommandLineParser/Core/Usage/UsageBuilder.cs
+++ b/CommandLineParser/Core/Usage/UsageBuilder.cs
@@ -60,7 +60,7 @@ namespace MatthiWare.CommandLine.Core.Usage
                 PrintCommandDescription(cmd, longestCommandName - cmd.Name.Length + descriptionShift);
         }
 
-        public void PrintOption(ICommandLineOption option, int descriptionShift = 4)
+        public void PrintOption(ICommandLineOption option, int descriptionShift = 4, bool compensateSeparator = false)
         {
             bool hasShort = option.HasShortName;
             bool hasLong = option.HasLongName;
@@ -70,7 +70,7 @@ namespace MatthiWare.CommandLine.Core.Usage
             string shortName = hasShort ? option.ShortName : string.Empty;
             string longName = hasLong ? option.LongName : string.Empty;
 
-            stringBuilder.AppendLine($"  {shortName}{hasBothSeparator}{longName}{new string(' ', descriptionShift)}{option.Description}");
+            stringBuilder.AppendLine($"  {shortName}{hasBothSeparator}{longName}{new string(' ', descriptionShift + (compensateSeparator && !hasBoth ? 1 : 0))}{option.Description}");
         }
 
         public void PrintOptions(IEnumerable<ICommandLineOption> options, int descriptionShift = 4)
@@ -79,10 +79,10 @@ namespace MatthiWare.CommandLine.Core.Usage
 
             stringBuilder.AppendLine().AppendLine("Options: ");
 
-            var longestOptionName = options.Max(x => x.ShortName.Length + x.LongName.Length);
-            var separatorCompensation = options.Any(x => x.HasShortName && x.HasLongName) ? 1 : 0;
+            var longestOptionName = options.Max(x => (x.HasShortName ? x.ShortName.Length : 0) + (x.HasLongName ? x.LongName.Length : 0));
+            var compensateSeparator = options.Any(x => x.HasShortName && x.HasLongName);
             foreach (var opt in options)
-                PrintOption(opt, longestOptionName - opt.LongName.Length - opt.ShortName.Length + separatorCompensation + descriptionShift);
+                PrintOption(opt, longestOptionName - (opt.HasLongName ? opt.LongName.Length : 0) - (opt.HasShortName ? opt.ShortName.Length : 0) + descriptionShift, compensateSeparator);
         }
     }
 }

--- a/CommandLineParser/Core/Usage/UsageBuilder.cs
+++ b/CommandLineParser/Core/Usage/UsageBuilder.cs
@@ -89,7 +89,6 @@ namespace MatthiWare.CommandLine.Core.Usage
 
             foreach (var opt in options)
             {
-
                 var longNameLength = opt.HasLongName ? opt.LongName.Length : 0;
                 var shortNameLength = opt.HasShortName ? opt.ShortName.Length : 0;
                 descriptionShift = longestOptionName - longNameLength - shortNameLength + descriptionShift;


### PR DESCRIPTION
- Fixes: #32 
- Options and commands descriptions shifting should be based on the longest one


```
Usage: ck550-cli [commands]

Commands:
  effect-breathing           Set a breathing effect
  effect-color-cycle         Set a color-cycle effect
  effect-circle-spectrum     Set a circle-spectrum effect
  effect-crosshair           Set a crosshair effect
  effect-fireball            Set a fireball effect
  effect-heartbeat           Set a heartbeat effect
  effect-off                 Set an off effect
  effect-reactive-punch      Set a reactive-punch effect
  effect-reactive-tornado    Set a reactive-tornado effect
  effect-ripple              Set a ripple effect
  effect-single-key          Set a single-key effect
  effect-snowing             Set a snowing effect
  effect-stars               Set a stars effect
  effect-static              Set a static effect
  effect-water-ripple        Set a water-ripple effect
  effect-wave-ripple         Set a wave effect
```
```
Usage: dotnet [options] [commands]

Options:
  -i|--int        Description for -s option, needs a string.
  -s|--string     Description for -s option, needs a string.
  -b|--bool       Description for -s option, needs a string.
  -d|--double     Description for -s option, needs a string.

Commands:
  start    Start the server command.
```