### PR TITLE
Split key on postfix value if needed

### DIFF
--- a/CommandLineParser.Tests/CommandLineParserTests.cs
+++ b/CommandLineParser.Tests/CommandLineParserTests.cs
@@ -29,7 +29,6 @@ namespace MatthiWare.CommandLine.Tests
             }
         }
 
-
         [Theory]
         [InlineData(true)]
         [InlineData(false)]

--- a/CommandLineParser.Tests/CommandLineParserTests.cs
+++ b/CommandLineParser.Tests/CommandLineParserTests.cs
@@ -29,6 +29,31 @@ namespace MatthiWare.CommandLine.Tests
             }
         }
 
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void CommandLineParserParsesCorrectOptionsWithPostfix(bool useShort)
+        {
+            var config = new CommandLineParserOptions
+            {
+                PostfixLongOption = "=",
+                PostfixShortOption = "="
+            };
+
+            var query = $"{(useShort ? "-" : "--")}p=some text";
+
+            var parser = new CommandLineParser<AddOption>(config);
+
+            parser.Configure(p => p.Message).Name("p", "p").Required();
+
+            var result = parser.Parse(new string[] { query });
+
+            result.AssertNoErrors();
+
+            Assert.Equal("some text", result.Result.Message);
+        }
+
         [Fact]
         public void CommandLineParserUsesCorrectOptions()
         {

--- a/CommandLineParser.Tests/CommandLineParserTests.cs
+++ b/CommandLineParser.Tests/CommandLineParserTests.cs
@@ -35,15 +35,9 @@ namespace MatthiWare.CommandLine.Tests
         [InlineData(false)]
         public void CommandLineParserParsesCorrectOptionsWithPostfix(bool useShort)
         {
-            var config = new CommandLineParserOptions
-            {
-                PostfixLongOption = "=",
-                PostfixShortOption = "="
-            };
-
             var query = $"{(useShort ? "-" : "--")}p=some text";
 
-            var parser = new CommandLineParser<AddOption>(config);
+            var parser = new CommandLineParser<AddOption>();
 
             parser.Configure(p => p.Message).Name("p", "p").Required();
 
@@ -199,7 +193,7 @@ namespace MatthiWare.CommandLine.Tests
 
         [Theory]
         [InlineData(new[] { "app.exe", "-e", "Opt1" }, false, EnumOption.Opt1)]
-        [InlineData(new[] { "app.exe", "-e", "opt1" }, false, EnumOption.Opt1)]
+        [InlineData(new[] { "app.exe", "-e=opt1" }, false, EnumOption.Opt1)]
         [InlineData(new[] { "app.exe", "-e", "Opt2" }, false, EnumOption.Opt2)]
         [InlineData(new[] { "app.exe", "-e", "bla" }, true, default(EnumOption))]
         [InlineData(new[] { "app.exe", "-e" }, true, default(EnumOption))]
@@ -220,11 +214,11 @@ namespace MatthiWare.CommandLine.Tests
 
         [Theory]
         // string
-        [InlineData(typeof(string), new[] { "-1", "message1", "-2", "-3" }, "default", "message1", "default", "default")]
+        [InlineData(typeof(string), new[] { "-1=message1", "-2", "-3" }, "default", "message1", "default", "default")]
         [InlineData(typeof(string), new[] { "-1", "-2", "message2", "-3" }, "default", "default", "message2", "default")]
         [InlineData(typeof(string), new[] { "-1", "-2", "-3" }, "default", "default", "default", "default")]
         // bool
-        [InlineData(typeof(bool), new[] { "-1", "false", "-2", "-3" }, false, false, true, true)]
+        [InlineData(typeof(bool), new[] { "-1=false", "-2", "-3" }, false, false, true, true)]
         [InlineData(typeof(bool), new[] { "-1", "-2", "false", "-3" }, false, true, false, true)]
         [InlineData(typeof(bool), new[] { "-1", "-2", "-3" }, false, true, true, true)]
         //// int
@@ -341,7 +335,7 @@ namespace MatthiWare.CommandLine.Tests
                 .Name("m", "message")
                 .Required();
 
-            var parsed = parser.Parse(new string[] { "app.exe", "-o", "test", "add", "-m", "my message" });
+            var parsed = parser.Parse(new string[] { "app.exe", "-o", "test", "add", "-m=my message" });
 
             parsed.AssertNoErrors();
 

--- a/CommandLineParser.Tests/Utils/ExtensionMethodsTest.cs
+++ b/CommandLineParser.Tests/Utils/ExtensionMethodsTest.cs
@@ -1,6 +1,10 @@
 ﻿using Xunit;
 using MatthiWare.CommandLine.Core.Utils;
 using System.Linq;
+using System.Collections.Generic;
+using MatthiWare.CommandLine.Core;
+using Moq;
+using MatthiWare.CommandLine.Abstractions;
 
 namespace MatthiWare.CommandLine.Tests.Utils
 {
@@ -10,16 +14,69 @@ namespace MatthiWare.CommandLine.Tests.Utils
         [Fact]
         public void TestSplitOnPostFixWorksCorrectly()
         {
-            var input = new[] { "--test=1", "--test2=\"some value\"", "--blabla", "third" };
+            var settings = new CommandLineParserOptions();
 
-            var output = input.SplitOnPostfix(true, true, "=", "=").ToArray();
+            var mockTestOption1 = CreateMock(settings, "test").Object;
+            var mockTestOption2 = CreateMock(settings, "test2", "test2").Object;
+            var mockTestOption3 = CreateMock(settings, "test3").Object;
+            var mockTestOption4 = CreateMock(settings, "blabla", "blabla").Object;
+
+            var options = new[] 
+            {
+                mockTestOption1,
+                mockTestOption2,
+                mockTestOption3,
+                mockTestOption4
+            };
+
+            var input = new[] { "--test=1", "-test2=\"some value\"", "--test3=some value", "-blabla", "third" };
+            var output = input.SplitOnPostfix(settings, options).ToArray();
 
             Assert.Equal("--test", output[0]);
             Assert.Equal("1", output[1]);
-            Assert.Equal("--test2", output[2]);
+            Assert.Equal("-test2", output[2]);
             Assert.Equal("\"some value\"", output[3]);
-            Assert.Equal("--blabla", output[4]);
-            Assert.Equal("third", output[5]);
+            Assert.Equal("--test3", output[4]);
+            Assert.Equal("some value", output[5]);
+            Assert.Equal("-blabla", output[6]);
+            Assert.Equal("third", output[7]);
+        }
+
+        [Fact]
+        public void TestSplitOnPostFixWorksCorrectly_2()
+        {
+            var settings = new CommandLineParserOptions();
+
+            var testOption = CreateMock(settings, "test").Object;
+
+            var options = new[]
+            {
+                testOption,
+            };
+
+            var input = new[] { "--test", "some=value" };
+
+            var output = input.SplitOnPostfix(settings, options).ToArray();
+
+            Assert.Equal("--test", output[0]);
+            Assert.Equal("some=value", output[1]);
+        }
+
+        private Mock<ICommandLineOption> CreateMock(CommandLineParserOptions settings, string longName, string shortName = "")
+        {
+            var mock = new Mock<ICommandLineOption>();
+
+            mock.SetupGet(option => option.LongName).Returns($"{settings.PrefixLongOption}{longName}");
+            mock.SetupGet(option => option.HasLongName).Returns(true);
+
+            if (!string.IsNullOrWhiteSpace(shortName))
+            {
+                mock.SetupGet(option => option.ShortName).Returns($"{settings.PrefixShortOption}{shortName}");
+                mock.SetupGet(option => option.HasShortName).Returns(true);
+
+            }
+
+            return mock;
         }
 
     }

--- a/CommandLineParser.Tests/Utils/ExtensionMethodsTest.cs
+++ b/CommandLineParser.Tests/Utils/ExtensionMethodsTest.cs
@@ -1,0 +1,26 @@
+﻿using Xunit;
+using MatthiWare.CommandLine.Core.Utils;
+using System.Linq;
+
+namespace MatthiWare.CommandLine.Tests.Utils
+{
+    public class ExtensionMethodsTest
+    {
+
+        [Fact]
+        public void TestSplitOnPostFixWorksCorrectly()
+        {
+            var input = new[] { "--test=1", "--test2=\"some value\"", "--blabla", "third" };
+
+            var output = input.SplitOnPostfix(true, true, "=", "=").ToArray();
+
+            Assert.Equal("--test", output[0]);
+            Assert.Equal("1", output[1]);
+            Assert.Equal("--test2", output[2]);
+            Assert.Equal("\"some value\"", output[3]);
+            Assert.Equal("--blabla", output[4]);
+            Assert.Equal("third", output[5]);
+        }
+
+    }
+}

--- a/CommandLineParser.Tests/Utils/ExtensionMethodsTest.cs
+++ b/CommandLineParser.Tests/Utils/ExtensionMethodsTest.cs
@@ -1,8 +1,6 @@
 ﻿using Xunit;
 using MatthiWare.CommandLine.Core.Utils;
 using System.Linq;
-using System.Collections.Generic;
-using MatthiWare.CommandLine.Core;
 using Moq;
 using MatthiWare.CommandLine.Abstractions;
 
@@ -10,7 +8,6 @@ namespace MatthiWare.CommandLine.Tests.Utils
 {
     public class ExtensionMethodsTest
     {
-
         [Fact]
         public void TestSplitOnPostFixWorksCorrectly()
         {
@@ -78,6 +75,5 @@ namespace MatthiWare.CommandLine.Tests.Utils
 
             return mock;
         }
-
     }
 }

--- a/CommandLineParser.Tests/Utils/ExtensionMethodsTest.cs
+++ b/CommandLineParser.Tests/Utils/ExtensionMethodsTest.cs
@@ -70,7 +70,6 @@ namespace MatthiWare.CommandLine.Tests.Utils
             {
                 mock.SetupGet(option => option.ShortName).Returns($"{settings.PrefixShortOption}{shortName}");
                 mock.SetupGet(option => option.HasShortName).Returns(true);
-
             }
 
             return mock;

--- a/CommandLineParser/Abstractions/Command/Command.cs
+++ b/CommandLineParser/Abstractions/Command/Command.cs
@@ -3,7 +3,6 @@
     /// <summary>
     /// Defines a command
     /// </summary>
-    /// <typeparam name="TOptions">Base options of the command</typeparam>
     public abstract class Command
     {
         /// <summary>

--- a/CommandLineParser/Abstractions/Command/ICommandBuilder'.cs
+++ b/CommandLineParser/Abstractions/Command/ICommandBuilder'.cs
@@ -7,6 +7,7 @@ namespace MatthiWare.CommandLine.Abstractions.Command
     /// Configures commands using a fluent interface
     /// </summary>
     /// <typeparam name="TSource">Command options class</typeparam>
+    /// <typeparam name="TOption">Base option</typeparam>
     public interface ICommandBuilder<TOption, TSource> : ICommandConfigurationBuilder, ICommandExecutor<TOption, TSource>
         where TOption : class
         where TSource : class, new()

--- a/CommandLineParser/Abstractions/Command/ICommandBuilder.cs
+++ b/CommandLineParser/Abstractions/Command/ICommandBuilder.cs
@@ -26,7 +26,7 @@ namespace MatthiWare.CommandLine.Abstractions.Command
         /// <summary>
         /// Describes the command, used in the usage output. 
         /// </summary>
-        /// <param name="desc">description of the command</param>
+        /// <param name="description">description of the command</param>
         /// <returns><see cref="ICommandBuilder{TOption}"/></returns>
         ICommandBuilder<TOption> Description(string description);
 

--- a/CommandLineParser/Abstractions/Command/ICommandConfigurationBuilder.cs
+++ b/CommandLineParser/Abstractions/Command/ICommandConfigurationBuilder.cs
@@ -15,7 +15,7 @@
         /// <summary>
         /// Configures the description text for the command
         /// </summary>
-        /// <param name="required">True or false</param>
+        /// <param name="description">Description</param>
         /// <returns><see cref="ICommandConfigurationBuilder"/></returns>
         ICommandConfigurationBuilder Description(string description);
 

--- a/CommandLineParser/Abstractions/Command/ICommandLineCommand.cs
+++ b/CommandLineParser/Abstractions/Command/ICommandLineCommand.cs
@@ -5,9 +5,24 @@
     /// </summary>
     public interface ICommandLineCommand : IArgument
     {
+        /// <summary>
+        /// Name of the command
+        /// </summary>
         string Name { get; }
+
+        /// <summary>
+        /// Indicates if the command is required or not
+        /// </summary>
         bool IsRequired { get; }
+
+        /// <summary>
+        /// Description of the command
+        /// </summary>
         string Description { get; }
+
+        /// <summary>
+        /// Auto executes the command if set to true
+        /// </summary>
         bool AutoExecute { get; }
     }
 }

--- a/CommandLineParser/Abstractions/ICommandLineOption.cs
+++ b/CommandLineParser/Abstractions/ICommandLineOption.cs
@@ -5,12 +5,39 @@
     /// </summary>
     public interface ICommandLineOption : IArgument
     {
+        /// <summary>
+        /// Short name of the option
+        /// </summary>
         string ShortName { get; }
+
+        /// <summary>
+        /// Long name of the option
+        /// </summary>
         string LongName { get; }
+
+        /// <summary>
+        /// Description of the option
+        /// </summary>
         string Description { get; }
+
+        /// <summary>
+        /// Indicates if the option is required
+        /// </summary>
         bool IsRequired { get; }
+
+        /// <summary>
+        /// Indicates if a short option name has been specified
+        /// </summary>
         bool HasShortName { get; }
+
+        /// <summary>
+        /// Indicates if a long option name has been specified
+        /// </summary>
         bool HasLongName { get; }
+
+        /// <summary>
+        /// Inidicates if a default value has been specified for this option
+        /// </summary>
         bool HasDefault { get; }
     }
 }

--- a/CommandLineParser/CommandLineParser.xml
+++ b/CommandLineParser/CommandLineParser.xml
@@ -743,12 +743,7 @@
             Prefix for the long option
             </summary>
         </member>
-        <member name="P:MatthiWare.CommandLine.CommandLineParserOptions.PostfixShortOption">
-            <summary>
-            Postfix for the short option
-            </summary>
-        </member>
-        <member name="P:MatthiWare.CommandLine.CommandLineParserOptions.PostfixLongOption">
+        <member name="P:MatthiWare.CommandLine.CommandLineParserOptions.PostfixOption">
             <summary>
             Postfix for the long option
             </summary>

--- a/CommandLineParser/CommandLineParser.xml
+++ b/CommandLineParser/CommandLineParser.xml
@@ -743,6 +743,16 @@
             Prefix for the long option
             </summary>
         </member>
+        <member name="P:MatthiWare.CommandLine.CommandLineParserOptions.PostfixShortOption">
+            <summary>
+            Postfix for the short option
+            </summary>
+        </member>
+        <member name="P:MatthiWare.CommandLine.CommandLineParserOptions.PostfixLongOption">
+            <summary>
+            Postfix for the long option
+            </summary>
+        </member>
         <member name="P:MatthiWare.CommandLine.CommandLineParserOptions.HelpOptionName">
             <summary>
             Help option name. 

--- a/CommandLineParser/CommandLineParserOptions.cs
+++ b/CommandLineParser/CommandLineParserOptions.cs
@@ -15,6 +15,16 @@ namespace MatthiWare.CommandLine
         public string PrefixLongOption { get; set; } = "--";
 
         /// <summary>
+        /// Postfix for the short option
+        /// </summary>
+        public string PostfixShortOption { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Postfix for the long option
+        /// </summary>
+        public string PostfixLongOption { get; set; } = string.Empty;
+
+        /// <summary>
         /// Help option name. 
         /// Accepts both formatted and unformatted help name. 
         /// If the name is a single string it will use the <see cref="PrefixLongOption"/>

--- a/CommandLineParser/CommandLineParserOptions.cs
+++ b/CommandLineParser/CommandLineParserOptions.cs
@@ -15,14 +15,9 @@ namespace MatthiWare.CommandLine
         public string PrefixLongOption { get; set; } = "--";
 
         /// <summary>
-        /// Postfix for the short option
-        /// </summary>
-        public string PostfixShortOption { get; set; } = string.Empty;
-
-        /// <summary>
         /// Postfix for the long option
         /// </summary>
-        public string PostfixLongOption { get; set; } = string.Empty;
+        public string PostfixOption { get; set; } = "=";
 
         /// <summary>
         /// Help option name. 

--- a/CommandLineParser/CommandLineParser`TOption.cs
+++ b/CommandLineParser/CommandLineParser`TOption.cs
@@ -196,7 +196,7 @@ namespace MatthiWare.CommandLine
 
             var result = new ParseResult<TOption>();
 
-            var argumentManager = new ArgumentManager(args, ParserOptions.EnableHelpOption, m_helpOptionName, m_helpOptionNameLong, m_commands, m_options.Values);
+            var argumentManager = new ArgumentManager(args, ParserOptions, m_helpOptionName, m_helpOptionNameLong, m_commands, m_options.Values);
 
             ParseCommands(errors, result, argumentManager);
 

--- a/CommandLineParser/CommandLineParser`TOption.cs
+++ b/CommandLineParser/CommandLineParser`TOption.cs
@@ -196,7 +196,7 @@ namespace MatthiWare.CommandLine
 
             var result = new ParseResult<TOption>();
 
-            var argumentManager = new ArgumentManager(args, ParserOptions, m_helpOptionName, m_helpOptionNameLong, m_commands, m_options.Values);
+            var argumentManager = new ArgumentManager(args, ParserOptions, m_helpOptionName, m_helpOptionNameLong, m_commands, m_options.Values.Cast<ICommandLineOption>().ToArray());
 
             ParseCommands(errors, result, argumentManager);
 

--- a/CommandLineParser/Core/Utils/ExtensionMethods.cs
+++ b/CommandLineParser/Core/Utils/ExtensionMethods.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Text;
@@ -30,6 +31,34 @@ namespace MatthiWare.CommandLine.Core.Utils
             if (baseType == null) return false;
 
             return IsAssignableToGenericType(baseType, genericType);
+        }
+
+        public static IEnumerable<string> SplitOnPostfix(this IEnumerable<string> self, bool hasShortPostfix, bool hasLongPostfix, string shortPostfix, string longPostfix)
+        {
+            foreach (var item in self)
+            {
+                string[] tokens = null;
+                int idx = -1;
+
+                if (hasLongPostfix && (idx = item.IndexOf(longPostfix)) != -1)
+                {
+                    tokens = new []{ item.Substring(0, idx ), item.Substring(idx + 1, item.Length - idx - 1) };
+                } 
+                else if (hasShortPostfix && (idx = item.IndexOf(shortPostfix)) != -1)
+                {
+                    tokens = new[] { item.Substring(0, idx ), item.Substring(idx + 1, item.Length - idx - 1) };
+                }
+
+                if (idx != -1)
+                {
+                    yield return tokens[0];
+                    yield return tokens[1];
+                }
+                else
+                {
+                    yield return item;
+                }
+            }
         }
 
         public static LambdaExpression GetLambdaExpression(this PropertyInfo propInfo, out string key)

--- a/CommandLineParser/Core/Utils/ExtensionMethods.cs
+++ b/CommandLineParser/Core/Utils/ExtensionMethods.cs
@@ -21,7 +21,6 @@ namespace MatthiWare.CommandLine.Core.Utils
                 string longStr = $"{option.LongName}{settings.PostfixOption}";
 
                 return (option.HasShortName && item.StartsWith(shortStr)) || (option.HasLongName && item.StartsWith(longStr));
-
             }).FirstOrDefault();
         }
 


### PR DESCRIPTION
Fixes #42 allowes an given string to be defined between `key` and `value` by default `=`

For example `--key="some value"` is the same as `--key "some value"`