### PR TITLE
Allow RegisterCommand to receive Type arguments

### DIFF
--- a/CommandLineParser.Tests/Command/CommandTests.cs
+++ b/CommandLineParser.Tests/Command/CommandTests.cs
@@ -1,8 +1,6 @@
-﻿using System.Linq;
-
-using MatthiWare.CommandLine;
+﻿using MatthiWare.CommandLine;
 using MatthiWare.CommandLine.Abstractions.Command;
-
+using System.Linq;
 using Xunit;
 
 namespace MatthiWare.CommandLine.Tests.Command
@@ -37,36 +35,51 @@ namespace MatthiWare.CommandLine.Tests.Command
             Assert.NotNull(parser.Commands.First(cmd => cmd.Name.Equals("y")));
         }
 
-        [Fact]
-        public void AddCommandType()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void AddCommandType(bool generic)
         {
             var parser = new CommandLineParser<object>();
 
-            parser.RegisterCommand<MyComand>();
+            if (generic)
+                parser.RegisterCommand<MyComand>();
+            else
+                parser.RegisterCommand(typeof(MyComand));
 
             Assert.Equal(1, parser.Commands.Count);
 
             Assert.NotNull(parser.Commands.First(cmd => cmd.Name.Equals("bla")));
         }
 
-        [Fact]
-        public void AddOtherCommandType()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void AddOtherCommandType(bool generic)
         {
             var parser = new CommandLineParser<object>();
 
-            parser.RegisterCommand<OtherCommand>();
+            if (generic)
+                parser.RegisterCommand<OtherCommand>();
+            else
+                parser.RegisterCommand(typeof(OtherCommand));
 
             Assert.Equal(1, parser.Commands.Count);
 
             Assert.NotNull(parser.Commands.First(cmd => cmd.Name.Equals("other")));
         }
 
-        [Fact]
-        public void AddCommandTypeWithGenericOption()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void AddCommandTypeWithGenericOption(bool generic)
         {
             var parser = new CommandLineParser<object>();
 
-            parser.RegisterCommand<MyComand, object>();
+            if (generic)
+                parser.RegisterCommand<MyComand, object>();
+            else
+                parser.RegisterCommand(typeof(MyComand), typeof(object));
 
             Assert.Equal(1, parser.Commands.Count);
 

--- a/CommandLineParser.Tests/Command/MultipleCommandTests.cs
+++ b/CommandLineParser.Tests/Command/MultipleCommandTests.cs
@@ -12,7 +12,7 @@ namespace MatthiWare.CommandLine.Tests.Command
         [InlineData(new string[] { }, false)]
         public void NonRequiredCommandShouldNotSetResultInErrorStateWhenRequiredOptionsAreMissing(string[] args, bool _)
         {
-            var parser = new CommandLineParser<object>();
+            var parser = new CommandLineParser();
 
             parser.AddCommand<MultipleCOmmandTestsOptions>()
                 .Name("cmd1")

--- a/CommandLineParser.Tests/Command/RegisterCommandTests.cs
+++ b/CommandLineParser.Tests/Command/RegisterCommandTests.cs
@@ -1,0 +1,32 @@
+﻿using MatthiWare.CommandLine.Abstractions.Command;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+
+namespace MatthiWare.CommandLine.Tests.Command
+{
+    public class RegisterCommandTests
+    {
+        [Fact]
+        public void RegisterCommandWithNoneCommandTypeThrowsException()
+        {
+            var parser = new CommandLineParser();
+
+            Assert.Throws<ArgumentException>(() => parser.RegisterCommand(typeof(object)));
+        }
+
+        [Fact]
+        public void RegisterCommandWithWrongParentTypeThrowsException()
+        {
+            var parser = new CommandLineParser();
+
+            Assert.Throws<ArgumentException>(() => parser.RegisterCommand(typeof(MyWrongCommand)));
+        }
+
+        private class MyWrongCommand : Command<Exception, Exception>
+        {
+
+        }
+    }
+}

--- a/CommandLineParser.Tests/Command/RegisterCommandTests.cs
+++ b/CommandLineParser.Tests/Command/RegisterCommandTests.cs
@@ -1,7 +1,5 @@
 ﻿using MatthiWare.CommandLine.Abstractions.Command;
 using System;
-using System.Collections.Generic;
-using System.Text;
 using Xunit;
 
 namespace MatthiWare.CommandLine.Tests.Command
@@ -26,7 +24,6 @@ namespace MatthiWare.CommandLine.Tests.Command
 
         private class MyWrongCommand : Command<Exception, Exception>
         {
-
         }
     }
 }

--- a/CommandLineParser.Tests/Command/SubCommandTests.cs
+++ b/CommandLineParser.Tests/Command/SubCommandTests.cs
@@ -1,9 +1,9 @@
-﻿using System;
-using System.Threading;
-using MatthiWare.CommandLine;
+﻿using MatthiWare.CommandLine;
 using MatthiWare.CommandLine.Abstractions;
 using MatthiWare.CommandLine.Abstractions.Command;
 using MatthiWare.CommandLine.Core.Attributes;
+using System;
+using System.Threading;
 using Xunit;
 
 namespace MatthiWare.CommandLine.Tests.Command

--- a/CommandLineParser.Tests/Command/SubCommandTests.cs
+++ b/CommandLineParser.Tests/Command/SubCommandTests.cs
@@ -70,97 +70,97 @@ namespace MatthiWare.CommandLine.Tests.Command
                     throw new InvalidCastException($"Unable to resolve {(typeof(T)).Name}");
             }
         }
-    }
 
-    public class MainCommand : Command<MainModel, SubModel>
-    {
-        private readonly ManualResetEventSlim locker;
-        private readonly bool autoExecute;
-        private readonly string bla;
-        private readonly int i;
-        private readonly int n;
-
-        public MainCommand(ManualResetEventSlim locker, bool autoExecute, string bla, int i, int n)
+        public class MainCommand : Command<MainModel, SubModel>
         {
-            this.locker = locker;
-            this.autoExecute = autoExecute;
-            this.bla = bla;
-            this.i = i;
-            this.n = n;
+            private readonly ManualResetEventSlim locker;
+            private readonly bool autoExecute;
+            private readonly string bla;
+            private readonly int i;
+            private readonly int n;
+
+            public MainCommand(ManualResetEventSlim locker, bool autoExecute, string bla, int i, int n)
+            {
+                this.locker = locker;
+                this.autoExecute = autoExecute;
+                this.bla = bla;
+                this.i = i;
+                this.n = n;
+            }
+
+            public override void OnConfigure(ICommandConfigurationBuilder<SubModel> builder)
+            {
+                builder
+                    .Name("main")
+                    .AutoExecute(autoExecute)
+                    .Required();
+            }
+
+            public override void OnExecute(MainModel options, SubModel commandOptions)
+            {
+                base.OnExecute(options, commandOptions);
+
+                Assert.Equal(bla, options.Bla);
+                Assert.Equal(i, commandOptions.Item);
+
+                locker.Set();
+            }
         }
 
-        public override void OnConfigure(ICommandConfigurationBuilder<SubModel> builder)
+        public class SubCommand : Command<MainModel, SubSubModel>
         {
-            builder
-                .Name("main")
-                .AutoExecute(autoExecute)
-                .Required();
+            private readonly ManualResetEventSlim locker;
+            private readonly bool autoExecute;
+            private readonly string bla;
+            private readonly int i;
+            private readonly int n;
+
+            public SubCommand(ManualResetEventSlim locker, bool autoExecute, string bla, int i, int n)
+            {
+                this.locker = locker;
+                this.autoExecute = autoExecute;
+                this.bla = bla;
+                this.i = i;
+                this.n = n;
+            }
+
+            public override void OnConfigure(ICommandConfigurationBuilder<SubSubModel> builder)
+            {
+                builder
+                    .Name("sub")
+                    .AutoExecute(autoExecute)
+                    .Required();
+            }
+
+            public override void OnExecute(MainModel options, SubSubModel commandOptions)
+            {
+                base.OnExecute(options, commandOptions);
+
+                Assert.Equal(bla, options.Bla);
+                Assert.Equal(n, commandOptions.Nothing);
+
+                locker.Set();
+            }
         }
 
-        public override void OnExecute(MainModel options, SubModel commandOptions)
+        public class MainModel
         {
-            base.OnExecute(options, commandOptions);
-
-            Assert.Equal(bla, options.Bla);
-            Assert.Equal(i, commandOptions.Item);
-
-            locker.Set();
-        }
-    }
-
-    public class SubCommand : Command<MainModel, SubSubModel>
-    {
-        private readonly ManualResetEventSlim locker;
-        private readonly bool autoExecute;
-        private readonly string bla;
-        private readonly int i;
-        private readonly int n;
-
-        public SubCommand(ManualResetEventSlim locker, bool autoExecute, string bla, int i, int n)
-        {
-            this.locker = locker;
-            this.autoExecute = autoExecute;
-            this.bla = bla;
-            this.i = i;
-            this.n = n;
+            [Required, Name("b")]
+            public string Bla { get; set; }
+            public MainCommand MainCommand { get; set; }
         }
 
-        public override void OnConfigure(ICommandConfigurationBuilder<SubSubModel> builder)
+        public class SubModel
         {
-            builder
-                .Name("sub")
-                .AutoExecute(autoExecute)
-                .Required();
+            [Required, Name("i")]
+            public int Item { get; set; }
+            public SubCommand SubCommand { get; set; }
         }
 
-        public override void OnExecute(MainModel options, SubSubModel commandOptions)
+        public class SubSubModel
         {
-            base.OnExecute(options, commandOptions);
-
-            Assert.Equal(bla, options.Bla);
-            Assert.Equal(n, commandOptions.Nothing);
-
-            locker.Set();
+            [Required, Name("n")]
+            public int Nothing { get; set; }
         }
-    }
-
-    public class MainModel
-    {
-        [Required, Name("b")]
-        public string Bla { get; set; }
-        public MainCommand MainCommand { get; set; }
-    }
-
-    public class SubModel
-    {
-        [Required, Name("i")]
-        public int Item { get; set; }
-        public SubCommand SubCommand { get; set; }
-    }
-
-    public class SubSubModel
-    {
-        [Required, Name("n")]
-        public int Nothing { get; set; }
     }
 }

--- a/CommandLineParser.Tests/CommandLineParserTests.cs
+++ b/CommandLineParser.Tests/CommandLineParserTests.cs
@@ -1,15 +1,12 @@
-﻿using System;
-using System.Linq;
-using System.Threading;
-
-using MatthiWare.CommandLine.Abstractions;
+﻿using MatthiWare.CommandLine.Abstractions;
 using MatthiWare.CommandLine.Abstractions.Command;
 using MatthiWare.CommandLine.Abstractions.Models;
 using MatthiWare.CommandLine.Abstractions.Parsing;
 using MatthiWare.CommandLine.Core.Attributes;
-
 using Moq;
-
+using System;
+using System.Linq;
+using System.Threading;
 using Xunit;
 
 namespace MatthiWare.CommandLine.Tests
@@ -57,8 +54,10 @@ namespace MatthiWare.CommandLine.Tests
             Assert.Equal(opt, parser.ParserOptions);
         }
 
-        [Fact]
-        public void CommandLineParserUsesContainerCorrectly()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void CommandLineParserUsesContainerCorrectly(bool generic)
         {
             var commandMock = new Mock<MyCommand>();
             commandMock.Setup(
@@ -72,7 +71,10 @@ namespace MatthiWare.CommandLine.Tests
 
             var parser = new CommandLineParser<object>(containerMock.Object);
 
-            parser.RegisterCommand<MyCommand, object>();
+            if (generic)
+                parser.RegisterCommand<MyCommand, object>();
+            else
+                parser.RegisterCommand(typeof(MyCommand), typeof(object));
 
             var result = parser.Parse(new[] { "app.exe", "my" });
 

--- a/CommandLineParser/Abstractions/ICommandLineParser'.cs
+++ b/CommandLineParser/Abstractions/ICommandLineParser'.cs
@@ -1,9 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq.Expressions;
-using MatthiWare.CommandLine.Abstractions.Command;
+﻿using MatthiWare.CommandLine.Abstractions.Command;
 using MatthiWare.CommandLine.Abstractions.Parsing;
 using MatthiWare.CommandLine.Abstractions.Usage;
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
 
 namespace MatthiWare.CommandLine.Abstractions
 {
@@ -84,6 +84,19 @@ namespace MatthiWare.CommandLine.Abstractions
         void RegisterCommand<TCommand, TCommandOption>()
             where TCommand : Command<TOption, TCommandOption>
             where TCommandOption : class, new();
+
+        /// <summary>
+        /// Registers a new command
+        /// </summary>
+        /// <param name="commandType">The type of the command</param>
+        /// <param name="optionsType">Command options model</param>
+        void RegisterCommand(Type commandType, Type optionsType);
+
+        /// <summary>
+        /// Registers a new command
+        /// </summary>
+        /// <param name="commandType">The type of the command</param>
+        void RegisterCommand(Type commandType);
 
         #endregion
     }

--- a/CommandLineParser/Abstractions/Parsing/Command/ICommandParserResult.cs
+++ b/CommandLineParser/Abstractions/Parsing/Command/ICommandParserResult.cs
@@ -1,7 +1,7 @@
-﻿using System;
+﻿using MatthiWare.CommandLine.Abstractions.Command;
+using System;
 using System.Collections;
 using System.Collections.Generic;
-using MatthiWare.CommandLine.Abstractions.Command;
 
 namespace MatthiWare.CommandLine.Abstractions.Parsing.Command
 {
@@ -10,6 +10,11 @@ namespace MatthiWare.CommandLine.Abstractions.Parsing.Command
     /// </summary>
     public interface ICommandParserResult
     {
+        /// <summary>
+        /// Indicates if the command' <see cref="Command{TOptions, TCommandOptions}.OnExecute(TOptions, TCommandOptions)"/> method has been executed.
+        /// </summary>
+        bool Executed { get; }
+
         /// <summary>
         /// Indicates if the command has been found.
         /// </summary>

--- a/CommandLineParser/CommandLineParser.xml
+++ b/CommandLineParser/CommandLineParser.xml
@@ -564,6 +564,11 @@
             Results fo the command that has been parsed
             </summary>
         </member>
+        <member name="P:MatthiWare.CommandLine.Abstractions.Parsing.Command.ICommandParserResult.Executed">
+            <summary>
+            Indicates if the command' <see cref="M:MatthiWare.CommandLine.Abstractions.Command.Command`2.OnExecute(`0,`1)"/> method has been executed.
+            </summary>
+        </member>
         <member name="P:MatthiWare.CommandLine.Abstractions.Parsing.Command.ICommandParserResult.Found">
             <summary>
             Indicates if the command has been found.

--- a/CommandLineParser/CommandLineParser.xml
+++ b/CommandLineParser/CommandLineParser.xml
@@ -408,6 +408,19 @@
             <typeparam name="TCommand">The command</typeparam>
             <typeparam name="TCommandOption">Command options model</typeparam>
         </member>
+        <member name="M:MatthiWare.CommandLine.Abstractions.ICommandLineParser`1.RegisterCommand(System.Type,System.Type)">
+            <summary>
+            Registers a new command
+            </summary>
+            <param name="commandType">The type of the command</param>
+            <param name="optionsType">Command options model</param>
+        </member>
+        <member name="M:MatthiWare.CommandLine.Abstractions.ICommandLineParser`1.RegisterCommand(System.Type)">
+            <summary>
+            Registers a new command
+            </summary>
+            <param name="commandType">The type of the command</param>
+        </member>
         <member name="T:MatthiWare.CommandLine.Abstractions.IOptionBuilder">
             <summary>
             API for configuring options
@@ -996,12 +1009,25 @@
             </summary>
             <typeparam name="TCommand">Command type, must be inherit <see cref="T:MatthiWare.CommandLine.Abstractions.Command.Command`1"/></typeparam>
         </member>
+        <member name="M:MatthiWare.CommandLine.CommandLineParser`1.RegisterCommand(System.Type)">
+            <summary>
+            Registers a new command
+            </summary>
+            <param name="commandType">The type of the command</param>
+        </member>
         <member name="M:MatthiWare.CommandLine.CommandLineParser`1.RegisterCommand``2">
             <summary>
             Registers a command type
             </summary>
             <typeparam name="TCommand">Command type, must be inherit <see cref="T:MatthiWare.CommandLine.Abstractions.Command.Command`2"/></typeparam>
             <typeparam name="TCommandOption">The command options</typeparam>
+        </member>
+        <member name="M:MatthiWare.CommandLine.CommandLineParser`1.RegisterCommand(System.Type,System.Type)">
+            <summary>
+            Registers a new command
+            </summary>
+            <param name="commandType">The type of the command</param>
+            <param name="optionsType">Command options model</param>
         </member>
         <member name="M:MatthiWare.CommandLine.CommandLineParser`1.AddCommand">
             <summary>

--- a/CommandLineParser/CommandLineParser`TOption.cs
+++ b/CommandLineParser/CommandLineParser`TOption.cs
@@ -1,12 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
-using System.Linq.Expressions;
-using System.Reflection;
-using System.Runtime.CompilerServices;
-
-using MatthiWare.CommandLine.Abstractions;
+﻿using MatthiWare.CommandLine.Abstractions;
 using MatthiWare.CommandLine.Abstractions.Command;
 using MatthiWare.CommandLine.Abstractions.Models;
 using MatthiWare.CommandLine.Abstractions.Parsing;
@@ -20,6 +12,13 @@ using MatthiWare.CommandLine.Core.Parsing;
 using MatthiWare.CommandLine.Core.Parsing.Command;
 using MatthiWare.CommandLine.Core.Usage;
 using MatthiWare.CommandLine.Core.Utils;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("CommandLineParser.Tests")]
 
@@ -406,6 +405,8 @@ namespace MatthiWare.CommandLine
             m_commands.Add(command);
         }
 
+        public void RegisterCommand(Type commandType) => RegisterCommand(commandType, null);
+
         /// <summary>
         /// Registers a command type
         /// </summary>
@@ -424,6 +425,16 @@ namespace MatthiWare.CommandLine
             command.OnExecuting((Action<TOption, TCommandOption>)cmdConfigurator.OnExecute);
 
             m_commands.Add(command);
+        }
+
+        public void RegisterCommand(Type commandType, Type optionType)
+        {
+            if (!commandType.IsAssignableToGenericType(typeof(Command<>)))
+            {
+                throw new ArgumentException($"Provided command {commandType} is not assignable to {typeof(Command<>)}");
+            }
+
+            this.ExecuteGenericRegisterCommand(nameof(RegisterCommand), commandType, optionType);
         }
 
         /// <summary>
@@ -484,16 +495,13 @@ namespace MatthiWare.CommandLine
 
                 if (ignoreSet) continue; // Ignore the configured actions for this option.
 
-                if (propInfo.PropertyType.IsAssignableToGenericType(typeof(Command<>)))
-                {
-                    var genericTypes = propInfo.PropertyType.BaseType.GenericTypeArguments;
-                    var method = GetType().GetMethods().First(m =>
-                    {
-                        return (m.Name == nameof(RegisterCommand) && m.IsGenericMethod && m.GetGenericArguments().Length == genericTypes.Length);
-                    });
-                    var registerCommand = genericTypes.Length > 1 ? method.MakeGenericMethod(propInfo.PropertyType, genericTypes[1]) : method.MakeGenericMethod(propInfo.PropertyType);
+                var cmdType = propInfo.PropertyType;
 
-                    registerCommand.Invoke(this, null);
+                if (cmdType.IsAssignableToGenericType(typeof(Command<>)))
+                {
+                    var genericTypes = cmdType.BaseType.GenericTypeArguments;
+
+                    this.ExecuteGenericRegisterCommand(nameof(RegisterCommand), cmdType);
                 }
 
                 foreach (var action in actions)

--- a/CommandLineParser/CommandLineParser`TOption.cs
+++ b/CommandLineParser/CommandLineParser`TOption.cs
@@ -405,6 +405,10 @@ namespace MatthiWare.CommandLine
             m_commands.Add(command);
         }
 
+        /// <summary>
+        /// Registers a new command
+        /// </summary>
+        /// <param name="commandType">The type of the command</param>
         public void RegisterCommand(Type commandType) => RegisterCommand(commandType, null);
 
         /// <summary>
@@ -427,14 +431,19 @@ namespace MatthiWare.CommandLine
             m_commands.Add(command);
         }
 
-        public void RegisterCommand(Type commandType, Type optionType)
+        /// <summary>
+        /// Registers a new command
+        /// </summary>
+        /// <param name="commandType">The type of the command</param>
+        /// <param name="optionsType">Command options model</param>
+        public void RegisterCommand(Type commandType, Type optionsType)
         {
             if (!commandType.IsAssignableToGenericType(typeof(Command<>)))
             {
                 throw new ArgumentException($"Provided command {commandType} is not assignable to {typeof(Command<>)}");
             }
 
-            this.ExecuteGenericRegisterCommand(nameof(RegisterCommand), commandType, optionType);
+            this.ExecuteGenericRegisterCommand(nameof(RegisterCommand), commandType, optionsType);
         }
 
         /// <summary>

--- a/CommandLineParser/Core/Parsing/Command/CommandNotFoundParserResult.cs
+++ b/CommandLineParser/Core/Parsing/Command/CommandNotFoundParserResult.cs
@@ -1,9 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using MatthiWare.CommandLine.Abstractions;
+﻿using MatthiWare.CommandLine.Abstractions;
 using MatthiWare.CommandLine.Abstractions.Command;
 using MatthiWare.CommandLine.Abstractions.Parsing.Command;
+using System;
+using System.Collections.Generic;
+using System.Text;
 
 namespace MatthiWare.CommandLine.Core.Parsing.Command
 {
@@ -22,6 +22,8 @@ namespace MatthiWare.CommandLine.Core.Parsing.Command
         public bool HasErrors => false;
 
         public IReadOnlyCollection<Exception> Errors => new List<Exception>();
+
+        public bool Executed => false;
 
         public void ExecuteCommand() { }
 

--- a/CommandLineParser/Core/Parsing/Command/CommandParserResult.cs
+++ b/CommandLineParser/Core/Parsing/Command/CommandParserResult.cs
@@ -1,10 +1,10 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using MatthiWare.CommandLine.Abstractions;
+﻿using MatthiWare.CommandLine.Abstractions;
 using MatthiWare.CommandLine.Abstractions.Command;
 using MatthiWare.CommandLine.Abstractions.Parsing.Command;
 using MatthiWare.CommandLine.Core.Command;
+using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace MatthiWare.CommandLine.Core.Parsing.Command
 {
@@ -27,6 +27,8 @@ namespace MatthiWare.CommandLine.Core.Parsing.Command
         public IReadOnlyCollection<Exception> Errors => exceptions;
 
         public bool Found => true;
+
+        public bool Executed { get; private set; } = false;
 
         public CommandParserResult(CommandLineCommandBase command)
         {
@@ -52,6 +54,10 @@ namespace MatthiWare.CommandLine.Core.Parsing.Command
             commandParserResults.Add(result);
         }
 
-        public void ExecuteCommand() => m_cmd.Execute();
+        public void ExecuteCommand()
+        {
+            m_cmd.Execute();
+            Executed = true;
+        }
     }
 }

--- a/CommandLineParser/Core/Utils/ExtensionMethods.cs
+++ b/CommandLineParser/Core/Utils/ExtensionMethods.cs
@@ -62,9 +62,7 @@ namespace MatthiWare.CommandLine.Core.Utils
 
             var genericTypes = cmdType.BaseType.GenericTypeArguments;
             var amountGenericTypes = genericTypes.Length;
-
-            //if (genericTypes.Length != amountGenericArgs)
-            //    throw new ArgumentException($"Generic method '{methodName}' takes {amountGenericTypes} generic type arguments but only '{amountGenericArgs}' provided.");
+            var nonNullOptionTypes = optionTypes.Where(t => t != null).ToArray();
 
             var method = baseType.GetMethods().FirstOrDefault(m =>
             {
@@ -77,8 +75,14 @@ namespace MatthiWare.CommandLine.Core.Utils
             List<Type> types = new List<Type>();
             types.Add(cmdType);
 
-            if (optionTypes.Length > 1)
-                types.Add(optionTypes[1]);
+            if (genericTypes.Length > 1)
+            {
+                if (nonNullOptionTypes.Length > 0)
+                    types.Add(nonNullOptionTypes[0]);
+                else
+                    types.Add(genericTypes[1]);
+            }
+
 
             var methodInstance = method.MakeGenericMethod(types.ToArray());
 

--- a/CommandLineParser/Core/Utils/ExtensionMethods.cs
+++ b/CommandLineParser/Core/Utils/ExtensionMethods.cs
@@ -1,10 +1,10 @@
-﻿using System;
+﻿using MatthiWare.CommandLine.Abstractions;
+using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Text;
-using System.Linq;
-using MatthiWare.CommandLine.Abstractions;
 
 namespace MatthiWare.CommandLine.Core.Utils
 {
@@ -15,7 +15,7 @@ namespace MatthiWare.CommandLine.Core.Utils
             if (string.IsNullOrEmpty(settings.PostfixOption))
                 return null;
 
-            return options.Where(option => 
+            return options.Where(option =>
             {
                 string shortStr = $"{option.ShortName}{settings.PostfixOption}";
                 string longStr = $"{option.LongName}{settings.PostfixOption}";
@@ -54,6 +54,36 @@ namespace MatthiWare.CommandLine.Core.Utils
             var generic = method.MakeGenericMethod(propertyInfo.PropertyType);
 
             return generic.Invoke(source, args);
+        }
+
+        public static object ExecuteGenericRegisterCommand(this object obj, string methodName, Type cmdType, params Type[] optionTypes)
+        {
+            var baseType = obj.GetType();
+
+            var genericTypes = cmdType.BaseType.GenericTypeArguments;
+            var amountGenericTypes = genericTypes.Length;
+
+            //if (genericTypes.Length != amountGenericArgs)
+            //    throw new ArgumentException($"Generic method '{methodName}' takes {amountGenericTypes} generic type arguments but only '{amountGenericArgs}' provided.");
+
+            var method = baseType.GetMethods().FirstOrDefault(m =>
+            {
+                return (m.Name == methodName && m.IsGenericMethod && m.GetGenericArguments().Length == amountGenericTypes);
+            });
+
+            if (method == null)
+                throw new ArgumentException($"No method by the name '{methodName}' found that takes {amountGenericTypes} generic type arguments.");
+
+            List<Type> types = new List<Type>();
+            types.Add(cmdType);
+
+            if (optionTypes.Length > 1)
+                types.Add(optionTypes[1]);
+
+            var methodInstance = method.MakeGenericMethod(types.ToArray());
+
+            return methodInstance.Invoke(obj, null);
+
         }
 
         public static IEnumerable<string> SplitOnPostfix(this IEnumerable<string> self, CommandLineParserOptions settings, ICollection<ICommandLineOption> options)

--- a/CommandLineParser/Core/Utils/ExtensionMethods.cs
+++ b/CommandLineParser/Core/Utils/ExtensionMethods.cs
@@ -83,11 +83,9 @@ namespace MatthiWare.CommandLine.Core.Utils
                     types.Add(genericTypes[1]);
             }
 
-
             var methodInstance = method.MakeGenericMethod(types.ToArray());
 
             return methodInstance.Invoke(obj, null);
-
         }
 
         public static IEnumerable<string> SplitOnPostfix(this IEnumerable<string> self, CommandLineParserOptions settings, ICollection<ICommandLineOption> options)


### PR DESCRIPTION
Fixes #29 

Added:
- `RegisterCommand(typeof(Command), typeof(Options));`
- `RegisterCommand(typeof(Command));`