### PR TITLE
Add suggestions when mistyping commands/options

### DIFF
--- a/CommandLineParser.Tests/BasicDITests.cs
+++ b/CommandLineParser.Tests/BasicDITests.cs
@@ -27,7 +27,7 @@ namespace MatthiWare.CommandLine.Tests
 
             parser.RegisterCommand<MyCommandThatUsesService>();
 
-            var result = parser.Parse(new[] { "app.exe", "cmd" });
+            var result = parser.Parse(new[] { "cmd" });
 
             result.AssertNoErrors();
 

--- a/CommandLineParser.Tests/Command/CommandDiscoveryTests.cs
+++ b/CommandLineParser.Tests/Command/CommandDiscoveryTests.cs
@@ -68,7 +68,7 @@ namespace MatthiWare.CommandLine.Tests.Command
 
             parser.DiscoverCommands(Assembly.GetExecutingAssembly());
 
-            var result = await parser.ParseAsync(new[] { "app.exe", "cmd" });
+            var result = await parser.ParseAsync(new[] { "cmd" });
 
             myServiceMock.Verify(_ => _.Call(), Times.Once());
         }
@@ -87,7 +87,7 @@ namespace MatthiWare.CommandLine.Tests.Command
 
             parser.DiscoverCommands(typeof(NonGenericDiscoverableCommand).Assembly);
 
-            var result = await parser.ParseAsync(new[] { "app.exe", "cmd" });
+            var result = await parser.ParseAsync(new[] { "cmd" });
 
             Assert.True(parser.Commands.Count == 1);
 

--- a/CommandLineParser.Tests/CommandLineParserTests.cs
+++ b/CommandLineParser.Tests/CommandLineParserTests.cs
@@ -603,7 +603,7 @@ namespace MatthiWare.CommandLine.Tests
         }
 
         [Theory]
-        [InlineData(new string[] { "" }, "defaulttransformed", false)]
+        [InlineData(new string[] {  }, "defaulttransformed", false)]
         [InlineData(new string[] { "-m", "test" }, "testtransformed", false)]
         [InlineData(new string[] { "--message", "test" }, "testtransformed", false)]
         public void TransformationWorksAsExpected(string[] args, string expected, bool errors)

--- a/CommandLineParser.Tests/CommandLineParserTests.cs
+++ b/CommandLineParser.Tests/CommandLineParserTests.cs
@@ -38,7 +38,7 @@ namespace MatthiWare.CommandLine.Tests
 
             var parser = new CommandLineParser<OrderModel>(Services);
 
-            var result = parser.Parse(new string[] { "app.exe", from, to });
+            var result = parser.Parse(new string[] { from, to });
 
             result.AssertNoErrors();
 
@@ -54,7 +54,7 @@ namespace MatthiWare.CommandLine.Tests
 
             var parser = new CommandLineParser<OrderModel>(Services);
 
-            var result = parser.Parse(new string[] { "app.exe", "-r", "5", from, to });
+            var result = parser.Parse(new string[] { "-r", "5", from, to });
 
             result.AssertNoErrors();
 
@@ -76,7 +76,7 @@ namespace MatthiWare.CommandLine.Tests
                 Assert.Equal(to, model.To);
             });
 
-            var result = parser.Parse(new string[] { "app.exe", "cmd", from, to });
+            var result = parser.Parse(new string[] { "cmd", from, to });
 
             result.AssertNoErrors();
         }
@@ -89,7 +89,7 @@ namespace MatthiWare.CommandLine.Tests
 
             var parser = new CommandLineParser<OrderModel>(Services);
 
-            var result = parser.Parse(new string[] { "app.exe", from, "-r", "5", to });
+            var result = parser.Parse(new string[] { from, "-r", "5", to });
 
             Assert.True(result.HasErrors);
 
@@ -105,7 +105,7 @@ namespace MatthiWare.CommandLine.Tests
 
             var parser = new CommandLineParser<OrderModelInt>(Services);
 
-            var result = parser.Parse(new string[] { "app.exe", from.ToString(), "oops", to.ToString() });
+            var result = parser.Parse(new string[] { from.ToString(), "oops", to.ToString() });
 
             Assert.True(result.HasErrors);
 
@@ -123,7 +123,7 @@ namespace MatthiWare.CommandLine.Tests
 
             var parser = new CommandLineParser<OrderModelInt>(options, Services);
 
-            var result = parser.Parse(new string[] { "app.exe", "10", "20", "--", "some random stuff", "nothing to see here", "yadi yadi yadi", "-r", "10" });
+            var result = parser.Parse(new string[] { "10", "20", "--", "some random stuff", "nothing to see here", "yadi yadi yadi", "-r", "10" });
 
             result.AssertNoErrors();
 
@@ -203,7 +203,7 @@ namespace MatthiWare.CommandLine.Tests
                 parser.RegisterCommand(typeof(MyCommand), typeof(object));
             }
 
-            var result = parser.Parse(new[] { "app.exe", "my" });
+            var result = parser.Parse(new[] { "my" });
 
             result.AssertNoErrors();
 
@@ -238,7 +238,7 @@ namespace MatthiWare.CommandLine.Tests
                 parser.RegisterCommand(typeof(MyCommand), typeof(object));
             }
 
-            var result = await parser.ParseAsync(new[] { "app.exe", "my" });
+            var result = await parser.ParseAsync(new[] { "my" });
 
             result.AssertNoErrors();
 
@@ -299,7 +299,7 @@ namespace MatthiWare.CommandLine.Tests
                 .Default("Default message")
                 .Required();
 
-            var parsed = parser.Parse(new string[] { "app.exe", "-o", "test" });
+            var parsed = parser.Parse(new string[] { "-o", "test" });
 
             Assert.NotNull(parsed);
 
@@ -309,11 +309,11 @@ namespace MatthiWare.CommandLine.Tests
         }
 
         [Theory]
-        [InlineData(new[] { "app.exe", "-e", "Opt1" }, false, EnumOption.Opt1)]
-        [InlineData(new[] { "app.exe", "-e=opt1" }, false, EnumOption.Opt1)]
-        [InlineData(new[] { "app.exe", "-e", "Opt2" }, false, EnumOption.Opt2)]
-        [InlineData(new[] { "app.exe", "-e", "bla" }, true, default(EnumOption))]
-        [InlineData(new[] { "app.exe", "-e" }, true, default(EnumOption))]
+        [InlineData(new[] { "-e", "Opt1" }, false, EnumOption.Opt1)]
+        [InlineData(new[] { "-e=opt1" }, false, EnumOption.Opt1)]
+        [InlineData(new[] { "-e", "Opt2" }, false, EnumOption.Opt2)]
+        [InlineData(new[] { "-e", "bla" }, true, default(EnumOption))]
+        [InlineData(new[] { "-e" }, true, default(EnumOption))]
         public void ParseEnumInArguments(string[] args, bool hasErrors, EnumOption enumOption)
         {
             var parser = new CommandLineParser<EnumOptions>(Services);
@@ -439,7 +439,7 @@ namespace MatthiWare.CommandLine.Tests
                 .Name("m", "message")
                 .Required();
 
-            var parsed = await parser.ParseAsync(new string[] { "app.exe", "-o", "test", "add", "-m=my message" });
+            var parsed = await parser.ParseAsync(new string[] { "-o", "test", "add", "-m=my message" });
 
             parsed.AssertNoErrors();
 
@@ -451,8 +451,8 @@ namespace MatthiWare.CommandLine.Tests
         }
 
         [Theory]
-        [InlineData(new[] { "app.exe", "add", "-m", "message2", "-m", "message1" }, "message1", "message2")]
-        [InlineData(new[] { "app.exe", "-m", "message1", "add", "-m", "message2" }, "message1", "message2")]
+        [InlineData(new[] { "add", "-m", "message2", "-m", "message1" }, "message1", "message2")]
+        [InlineData(new[] { "-m", "message1", "add", "-m", "message2" }, "message1", "message2")]
         [InlineData(new[] { "add", "-m", "message2", "-m", "message1" }, "message1", "message2")]
         [InlineData(new[] { "-m", "message1", "add", "-m", "message2" }, "message1", "message2")]
         public void ParseCommandTests(string[] args, string result1, string result2)
@@ -487,8 +487,8 @@ namespace MatthiWare.CommandLine.Tests
         }
 
         [Theory]
-        [InlineData(new[] { "app.exe", "add", "-m", "message2", "-m", "message1" }, "message1", "message2")]
-        [InlineData(new[] { "app.exe", "-m", "message1", "add", "-m", "message2" }, "message1", "message2")]
+        [InlineData(new[] { "add", "-m", "message2", "-m", "message1" }, "message1", "message2")]
+        [InlineData(new[] { "-m", "message1", "add", "-m", "message2" }, "message1", "message2")]
         [InlineData(new[] { "add", "-m", "message2", "-m", "message1" }, "message1", "message2")]
         [InlineData(new[] { "-m", "message1", "add", "-m", "message2" }, "message1", "message2")]
         public async Task ParseCommandTestsAsync(string[] args, string result1, string result2)

--- a/CommandLineParser.Tests/Parsing/OptionClusteringTests.cs
+++ b/CommandLineParser.Tests/Parsing/OptionClusteringTests.cs
@@ -15,7 +15,7 @@ namespace MatthiWare.CommandLine.Tests.Parsing
         {
             var parser = new CommandLineParser<ClusteredOptions<bool>>(Services);
 
-            var result = parser.Parse(new[] { "app.exe", "-abc" });
+            var result = parser.Parse(new[] { "-abc" });
 
             result.AssertNoErrors();
 
@@ -31,7 +31,7 @@ namespace MatthiWare.CommandLine.Tests.Parsing
         {
             var parser = new CommandLineParser<ClusteredOptions<bool>>(Services);
 
-            var result = parser.Parse(new[] { "app.exe", "-abc", "false" });
+            var result = parser.Parse(new[] { "-abc", "false" });
 
             result.AssertNoErrors();
 
@@ -47,7 +47,7 @@ namespace MatthiWare.CommandLine.Tests.Parsing
         {
             var parser = new CommandLineParser<ClusteredOptions<bool>>(Services);
 
-            var result = parser.Parse(new[] { "app.exe", "-abc", "false", "-abc", "true" });
+            var result = parser.Parse(new[] { "-abc", "false", "-abc", "true" });
 
             result.AssertNoErrors();
 
@@ -70,7 +70,7 @@ namespace MatthiWare.CommandLine.Tests.Parsing
                 Assert.False(model.C);
             });
 
-            var result = parser.Parse(new[] { "app.exe", "cmd", "-abc", "false" });
+            var result = parser.Parse(new[] { "cmd", "-abc", "false" });
 
             result.AssertNoErrors();
         }
@@ -87,7 +87,7 @@ namespace MatthiWare.CommandLine.Tests.Parsing
                 Assert.False(model.C);
             });
 
-            var result = parser.Parse(new[] { "app.exe", "-abc", "cmd", "-abc", "false" });
+            var result = parser.Parse(new[] { "-abc", "cmd", "-abc", "false" });
 
             result.AssertNoErrors();
 
@@ -108,7 +108,7 @@ namespace MatthiWare.CommandLine.Tests.Parsing
                 Assert.Equal("false", model.C);
             });
 
-            var result = parser.Parse(new[] { "app.exe", "-abc", "works", "cmd", "-abc", "false" });
+            var result = parser.Parse(new[] { "-abc", "works", "cmd", "-abc", "false" });
 
             result.AssertNoErrors();
 

--- a/CommandLineParser.Tests/Usage/DamerauLevenshteinTests.cs
+++ b/CommandLineParser.Tests/Usage/DamerauLevenshteinTests.cs
@@ -105,7 +105,7 @@ namespace MatthiWare.CommandLine.Tests.Usage
 
             parser.AddCommand().Name("cmd");
 
-            var result = parser.Parse(new[] { "app.exe", "cmdd" });
+            var result = parser.Parse(new[] { "cmdd" });
 
             result.AssertNoErrors();
         }

--- a/CommandLineParser.Tests/Usage/DamerauLevenshteinTests.cs
+++ b/CommandLineParser.Tests/Usage/DamerauLevenshteinTests.cs
@@ -59,6 +59,14 @@ namespace MatthiWare.CommandLine.Tests.Usage
         }
 
         [Fact]
+        public void NoContainerReturnsEmptyResult()
+        {
+            var dl = new DamerauLevenshteinSuggestionProvider();
+
+            Assert.Empty(dl.GetSuggestions(string.Empty, null));
+        }
+
+        [Fact]
         public void InvalidSuggestionIsNotReturned()
         {
             var containerMock = new Mock<ICommandLineCommandContainer>();

--- a/CommandLineParser.Tests/Usage/DamerauLevenshteinTests.cs
+++ b/CommandLineParser.Tests/Usage/DamerauLevenshteinTests.cs
@@ -1,0 +1,113 @@
+﻿using MatthiWare.CommandLine.Abstractions;
+using MatthiWare.CommandLine.Abstractions.Command;
+using MatthiWare.CommandLine.Core.Usage;
+using Moq;
+using System.Collections.Generic;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace MatthiWare.CommandLine.Tests.Usage
+{
+    public class DamerauLevenshteinTests : TestBase
+    {
+        public DamerauLevenshteinTests(ITestOutputHelper testOutputHelper) : base(testOutputHelper)
+        {
+        }
+
+        [Theory]
+        [InlineData(3, "CA", "ABC")]
+        [InlineData(1, "Test", "Tst")]
+        [InlineData(0, "Test", "Test")]
+        [InlineData(4, "", "Test")]
+        [InlineData(4, "Test", "")]
+        public void DistanceOfStrings(int expected, string a, string b)
+        {
+            var dl = new DamerauLevenshteinSuggestionProvider();
+
+            Assert.Equal(expected, dl.FindDistance(a, b));
+        }
+
+        [Fact]
+        public void SuggestionsAreGatheredFromAllAvailablePlaces()
+        {
+            var containerMock = new Mock<ICommandLineCommandContainer>();
+            var cmdMock = new Mock<ICommandLineCommand>();
+            var optionMock = new Mock<ICommandLineOption>();
+
+            cmdMock.SetupGet(_ => _.Name).Returns("test1");
+            optionMock.SetupGet(_ => _.HasLongName).Returns(true);
+            optionMock.SetupGet(_ => _.HasShortName).Returns(true);
+            optionMock.SetupGet(_ => _.LongName).Returns("test2");
+            optionMock.SetupGet(_ => _.ShortName).Returns("test3");
+
+            containerMock.SetupGet(_ => _.Commands).Returns(AsList(cmdMock.Object));
+            containerMock.SetupGet(_ => _.Options).Returns(AsList(optionMock.Object));
+
+            var dl = new DamerauLevenshteinSuggestionProvider();
+
+            var result = dl.GetSuggestions("test", containerMock.Object);
+
+            Assert.Contains("test1", result);
+            Assert.Contains("test2", result);
+            Assert.Contains("test3", result);
+
+            List<T> AsList<T>(T obj)
+            {
+                var list = new List<T>(1) { obj };
+                return list;
+            }
+        }
+
+        [Fact]
+        public void InvalidSuggestionIsNotReturned()
+        {
+            var containerMock = new Mock<ICommandLineCommandContainer>();
+            var cmdMock = new Mock<ICommandLineCommand>();
+            var optionMock = new Mock<ICommandLineOption>();
+
+            cmdMock.SetupGet(_ => _.Name).Returns("test");
+
+            containerMock.SetupGet(_ => _.Commands).Returns(AsList(cmdMock.Object));
+            containerMock.SetupGet(_ => _.Options).Returns(new List<ICommandLineOption>());
+
+            var dl = new DamerauLevenshteinSuggestionProvider();
+
+            var result = dl.GetSuggestions("abc", containerMock.Object);
+
+            Assert.Empty(result);
+
+            List<T> AsList<T>(T obj)
+            {
+                var list = new List<T>(1) { obj };
+                return list;
+            }
+        }
+
+        [Fact]
+        public void NoSuggestionsReturnsEmpty()
+        {
+            var containerMock = new Mock<ICommandLineCommandContainer>();
+
+            containerMock.SetupGet(_ => _.Commands).Returns(new List<ICommandLineCommand>());
+            containerMock.SetupGet(_ => _.Options).Returns(new List<ICommandLineOption>());
+
+            var dl = new DamerauLevenshteinSuggestionProvider();
+
+            var result = dl.GetSuggestions("abc", containerMock.Object);
+
+            Assert.Empty(result);
+        }
+
+        [Fact]
+        public void Test()
+        {
+            var parser = new CommandLineParser(Services);
+
+            parser.AddCommand().Name("cmd");
+
+            var result = parser.Parse(new[] { "app.exe", "cmdd" });
+
+            result.AssertNoErrors();
+        }
+    }
+}

--- a/CommandLineParser.Tests/Usage/NoColorOutputTests.cs
+++ b/CommandLineParser.Tests/Usage/NoColorOutputTests.cs
@@ -23,15 +23,18 @@ namespace MatthiWare.CommandLine.Tests.Usage
             var envMock = new Mock<IEnvironmentVariablesService>();
             envMock.SetupGet(env => env.NoColorRequested).Returns(() => variableServiceResult);
 
+            var consoleMock = new Mock<IConsole>();
+
             variablesService = envMock.Object;
 
             var usageBuilderMock = new Mock<IUsageBuilder>();
             usageBuilderMock.Setup(m => m.AddErrors(It.IsAny<IReadOnlyCollection<Exception>>())).Callback(() =>
             {
-                consoleColorGetter(((UsagePrinter)parser.Printer).m_currentConsoleColor);
+                consoleColorGetter(consoleMock.Object.ForegroundColor);
             });
 
             Services.AddSingleton(envMock.Object);
+            Services.AddSingleton(consoleMock.Object);
             Services.AddSingleton(usageBuilderMock.Object);
 
             parser = new CommandLineParser<Options>(Services);

--- a/CommandLineParser.Tests/Usage/UsagePrinterTests.cs
+++ b/CommandLineParser.Tests/Usage/UsagePrinterTests.cs
@@ -8,6 +8,7 @@ using MatthiWare.CommandLine.Core.Exceptions;
 using MatthiWare.CommandLine.Core.Usage;
 using Microsoft.Extensions.DependencyInjection;
 using Moq;
+using System;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -199,6 +200,30 @@ namespace MatthiWare.CommandLine.Tests.Usage
             // ASSERT
             consoleMock.VerifyAll();
             Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void TestNoSuggestion()
+        {
+            var usageBuilderMock = new Mock<IUsageBuilder>();
+            var suggestionProviderMock = new Mock<ISuggestionProvider>();
+
+            suggestionProviderMock
+                .Setup(_ => _.GetSuggestions(It.IsAny<string>(), It.IsAny<ICommandLineCommandContainer>()))
+                .Returns(Array.Empty<string>());
+
+            Services.AddSingleton(usageBuilderMock.Object);
+            Services.AddSingleton(suggestionProviderMock.Object);
+            Services.AddSingleton(Logger);
+
+            var parser = new CommandLineParser<OptionModel>(Services);
+
+            // ACT
+            parser.Parse(new[] { "tst" }).AssertNoErrors();
+
+            // ASSERT
+            usageBuilderMock.Verify(_ => _.AddSuggestion(It.IsAny<string>()), Times.Never());
+            usageBuilderMock.Verify(_ => _.AddSuggestionHeader(It.IsAny<string>()), Times.Never());
         }
 
         [Fact]

--- a/CommandLineParser.Tests/Usage/UsagePrinterTests.cs
+++ b/CommandLineParser.Tests/Usage/UsagePrinterTests.cs
@@ -175,7 +175,7 @@ namespace MatthiWare.CommandLine.Tests.Usage
         {
             // SETUP
             string result = string.Empty;
-            var expected = "'tst' is not recognized as a valid command or option.\r\n\r\nDid you mean: \r\n\tTest\r\n";
+            var expected = $"'tst' is not recognized as a valid command or option.{Environment.NewLine}{Environment.NewLine}Did you mean: {Environment.NewLine}\tTest{Environment.NewLine}";
 
             var consoleMock = new Mock<IConsole>();
             consoleMock.Setup(_ => _.WriteLine(It.IsAny<string>())).Callback((string s) => result = s).Verifiable();
@@ -231,7 +231,7 @@ namespace MatthiWare.CommandLine.Tests.Usage
         {
             // SETUP
             string result = string.Empty;
-            var expected = "'tst' is not recognized as a valid command or option.\r\n\r\nDid you mean: \r\n\tTest\r\n";
+            var expected = $"'tst' is not recognized as a valid command or option.{Environment.NewLine}{Environment.NewLine}Did you mean: {Environment.NewLine}\tTest{Environment.NewLine}";
 
             var consoleMock = new Mock<IConsole>();
             consoleMock.Setup(_ => _.WriteLine(It.IsAny<string>())).Callback((string s) => result += s).Verifiable();

--- a/CommandLineParser.Tests/Usage/UsagePrinterTests.cs
+++ b/CommandLineParser.Tests/Usage/UsagePrinterTests.cs
@@ -1,8 +1,11 @@
 ﻿using MatthiWare.CommandLine.Abstractions;
 using MatthiWare.CommandLine.Abstractions.Command;
+using MatthiWare.CommandLine.Abstractions.Parsing;
 using MatthiWare.CommandLine.Abstractions.Usage;
 using MatthiWare.CommandLine.Core.Attributes;
+using MatthiWare.CommandLine.Core.Command;
 using MatthiWare.CommandLine.Core.Exceptions;
+using MatthiWare.CommandLine.Core.Usage;
 using Microsoft.Extensions.DependencyInjection;
 using Moq;
 using Xunit;
@@ -166,7 +169,24 @@ namespace MatthiWare.CommandLine.Tests.Usage
                 ToTimes(optPassed));
         }
 
+        [Fact]
+        public void TestSuggestion()
+        {
+            var builder = new UsageBuilder(new CommandLineParserOptions());
+            var commandMock = new Mock<CommandLineCommandBase>();
+            var environmentService = Mock.Of<IEnvironmentVariablesService>();
+            var suggestionsProvider = new DamerauLevenshteinSuggestionProvider();
+            var model = new UnusedArgumentModel("tst", commandMock.Object);
+
+            var printer = new UsagePrinter(commandMock.Object, builder, environmentService, suggestionsProvider);
+
+            printer.PrintSuggestion(model);
+
+            var result = printer.
+        }
+
         private Times ToTimes(bool input)
             => input ? Times.Once() : Times.Never();
     }
 }
+ 

--- a/CommandLineParser/Abstractions/Command/ICommandLineCommandContainer.cs
+++ b/CommandLineParser/Abstractions/Command/ICommandLineCommandContainer.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq.Expressions;
 
 namespace MatthiWare.CommandLine.Abstractions.Command
 {

--- a/CommandLineParser/Abstractions/Usage/IConsole.cs
+++ b/CommandLineParser/Abstractions/Usage/IConsole.cs
@@ -8,6 +8,11 @@ namespace MatthiWare.CommandLine.Abstractions.Usage
     public interface IConsole
     {
         /// <summary>
+        /// <inheritdoc cref="Console.WriteLine()"/>
+        /// </summary>
+        void WriteLine();
+
+        /// <summary>
         /// <inheritdoc cref="Console.WriteLine(string)"/>
         /// </summary>
         /// <param name="text">Input text</param>

--- a/CommandLineParser/Abstractions/Usage/IConsole.cs
+++ b/CommandLineParser/Abstractions/Usage/IConsole.cs
@@ -1,0 +1,32 @@
+﻿using System;
+
+namespace MatthiWare.CommandLine.Abstractions.Usage
+{
+    /// <summary>
+    /// <inheritdoc cref="Console"/>
+    /// </summary>
+    public interface IConsole
+    {
+        /// <summary>
+        /// <inheritdoc cref="Console.WriteLine(string)"/>
+        /// </summary>
+        /// <param name="text">Input text</param>
+        void WriteLine(string text);
+
+        /// <summary>
+        /// <inheritdoc cref="Console.Error"/>
+        /// </summary>
+        /// <param name="text">Input text</param>
+        void ErrorWriteLine(string text);
+
+        /// <summary>
+        /// <inheritdoc cref="Console.ForegroundColor"/>
+        /// </summary>
+        ConsoleColor ForegroundColor { get; set; }
+
+        /// <summary>
+        /// <inheritdoc cref="Console.ResetColor"/>
+        /// </summary>
+        void ResetColor();
+    }
+}

--- a/CommandLineParser/Abstractions/Usage/ISuggestionProvider.cs
+++ b/CommandLineParser/Abstractions/Usage/ISuggestionProvider.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using MatthiWare.CommandLine.Abstractions.Command;
+using System.Collections.Generic;
 
 namespace MatthiWare.CommandLine.Abstractions.Usage
 {
@@ -11,7 +12,8 @@ namespace MatthiWare.CommandLine.Abstractions.Usage
         /// Gets a list of matching suggestions
         /// </summary>
         /// <param name="input">The wrongly typed input</param>
+        /// <param name="command">The current command context</param>
         /// <returns>A sorted list of suggestions, first item being the best match.</returns>
-        IEnumerable<string> GetSuggestions(string input);
+        IEnumerable<string> GetSuggestions(string input, ICommandLineCommandContainer command);
     }
 }

--- a/CommandLineParser/Abstractions/Usage/ISuggestionProvider.cs
+++ b/CommandLineParser/Abstractions/Usage/ISuggestionProvider.cs
@@ -1,0 +1,17 @@
+﻿using System.Collections.Generic;
+
+namespace MatthiWare.CommandLine.Abstractions.Usage
+{
+    /// <summary>
+    /// Creates suggestions based on input
+    /// </summary>
+    public interface ISuggestionProvider
+    {
+        /// <summary>
+        /// Gets a list of matching suggestions
+        /// </summary>
+        /// <param name="input">The wrongly typed input</param>
+        /// <returns>A sorted list of suggestions, first item being the best match.</returns>
+        IEnumerable<string> GetSuggestions(string input);
+    }
+}

--- a/CommandLineParser/Abstractions/Usage/IUsageBuilder.cs
+++ b/CommandLineParser/Abstractions/Usage/IUsageBuilder.cs
@@ -66,5 +66,8 @@ namespace MatthiWare.CommandLine.Abstractions.Usage
         /// </summary>
         /// <param name="errors"></param>
         void AddErrors(IReadOnlyCollection<Exception> errors);
+
+        void AddSuggestionHeader(string inputKey);
+        void AddSuggestion(string suggestion);
     }
 }

--- a/CommandLineParser/Abstractions/Usage/IUsagePrinter.cs
+++ b/CommandLineParser/Abstractions/Usage/IUsagePrinter.cs
@@ -1,4 +1,5 @@
 ﻿using MatthiWare.CommandLine.Abstractions.Command;
+using MatthiWare.CommandLine.Abstractions.Parsing;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -61,5 +62,7 @@ namespace MatthiWare.CommandLine.Abstractions.Usage
         /// </summary>
         /// <param name="errors">list of errors</param>
         void PrintErrors(IReadOnlyCollection<Exception> errors);
+
+        void PrintSuggestion(UnusedArgumentModel model);
     }
 }

--- a/CommandLineParser/CommandLineParser.xml
+++ b/CommandLineParser/CommandLineParser.xml
@@ -1777,7 +1777,7 @@
         <member name="P:MatthiWare.CommandLine.Core.Usage.UsagePrinter.Builder">
             <inheritdoc/>
         </member>
-        <member name="M:MatthiWare.CommandLine.Core.Usage.UsagePrinter.#ctor(MatthiWare.CommandLine.Abstractions.Command.ICommandLineCommandContainer,MatthiWare.CommandLine.Abstractions.Usage.IUsageBuilder,MatthiWare.CommandLine.Abstractions.Usage.IEnvironmentVariablesService)">
+        <member name="M:MatthiWare.CommandLine.Core.Usage.UsagePrinter.#ctor(MatthiWare.CommandLine.Abstractions.Command.ICommandLineCommandContainer,MatthiWare.CommandLine.Abstractions.Usage.IUsageBuilder,MatthiWare.CommandLine.Abstractions.Usage.IEnvironmentVariablesService,MatthiWare.CommandLine.Abstractions.Usage.ISuggestionProvider)">
             <summary>
             Creates a new CLI output usage printer
             </summary>

--- a/CommandLineParser/CommandLineParser.xml
+++ b/CommandLineParser/CommandLineParser.xml
@@ -1211,7 +1211,7 @@
             <summary>
             Help option name. 
             Accepts both formatted and unformatted help name. 
-            If the name is a single string it will use the <see cref="P:MatthiWare.CommandLine.CommandLineParserOptions.PrefixLongOption"/>
+            If the name is a single string it will use the <see cref="P:MatthiWare.CommandLine.CommandLineParserOptions.HelpOptionName"/>
             If the name is split for example h|help it will use the following format <![CDATA[<shortOption>|<longOption>]]>
             </summary>
         </member>

--- a/CommandLineParser/CommandLineParser.xml
+++ b/CommandLineParser/CommandLineParser.xml
@@ -925,6 +925,19 @@
             https://no-color.org/
             </summary>
         </member>
+        <member name="T:MatthiWare.CommandLine.Abstractions.Usage.ISuggestionProvider">
+            <summary>
+            Creates suggestions based on input
+            </summary>
+        </member>
+        <member name="M:MatthiWare.CommandLine.Abstractions.Usage.ISuggestionProvider.GetSuggestions(System.String,MatthiWare.CommandLine.Abstractions.Command.ICommandLineCommandContainer)">
+            <summary>
+            Gets a list of matching suggestions
+            </summary>
+            <param name="input">The wrongly typed input</param>
+            <param name="command">The current command context</param>
+            <returns>A sorted list of suggestions, first item being the best match.</returns>
+        </member>
         <member name="T:MatthiWare.CommandLine.Abstractions.Usage.IUsageBuilder">
             <summary>
             Output builder
@@ -1707,6 +1720,17 @@
             Gets the values from the cache. This will instantiate unresolved items. 
             </summary>
             <returns></returns>
+        </member>
+        <member name="M:MatthiWare.CommandLine.Core.Usage.DamerauLevenshteinSuggestionProvider.FindDistance(System.String@,System.String@)">
+            <summary>
+            Damerau-Levenshtein Distance algorithm implemented using Optimal String Alignment Distance. 
+            </summary>
+            <remarks>
+            https://en.wikipedia.org/wiki/Damerau%E2%80%93Levenshtein_distance
+            </remarks>
+            <param name="input">string A</param>
+            <param name="suggestion">string B</param>
+            <returns>Damerau-Levenshtein Distance</returns>
         </member>
         <member name="T:MatthiWare.CommandLine.Core.Usage.EnvironmentVariableService">
             <inheritdoc/>

--- a/CommandLineParser/CommandLineParser.xml
+++ b/CommandLineParser/CommandLineParser.xml
@@ -341,7 +341,7 @@
         <member name="P:MatthiWare.CommandLine.Abstractions.Command.ICommandLineCommandContainer.Options">
             <summary>
             Read-only list of available options for this command
-            <see cref="!:ICommandLineParser&lt;TOption&gt;.Configure&lt;TProperty&gt;(Expression&lt;Func&lt;TOption, TProperty&gt;&gt;)"/> to configure or add an option
+            <see cref="M:MatthiWare.CommandLine.Abstractions.ICommandLineParser`1.Configure``1(System.Linq.Expressions.Expression{System.Func{`0,``0}})"/> to configure or add an option
             </summary>
         </member>
         <member name="T:MatthiWare.CommandLine.Abstractions.Command.ICommandLineCommandParser">
@@ -912,6 +912,38 @@
             <summary>
             Read-only collection that contains the parsed commands' results. 
             <see cref="T:MatthiWare.CommandLine.Abstractions.Parsing.Command.ICommandParserResult"/>
+            </summary>
+        </member>
+        <member name="T:MatthiWare.CommandLine.Abstractions.Usage.IConsole">
+            <summary>
+            <inheritdoc cref="T:System.Console"/>
+            </summary>
+        </member>
+        <member name="M:MatthiWare.CommandLine.Abstractions.Usage.IConsole.WriteLine">
+            <summary>
+            <inheritdoc cref="M:System.Console.WriteLine"/>
+            </summary>
+        </member>
+        <member name="M:MatthiWare.CommandLine.Abstractions.Usage.IConsole.WriteLine(System.String)">
+            <summary>
+            <inheritdoc cref="M:System.Console.WriteLine(System.String)"/>
+            </summary>
+            <param name="text">Input text</param>
+        </member>
+        <member name="M:MatthiWare.CommandLine.Abstractions.Usage.IConsole.ErrorWriteLine(System.String)">
+            <summary>
+            <inheritdoc cref="P:System.Console.Error"/>
+            </summary>
+            <param name="text">Input text</param>
+        </member>
+        <member name="P:MatthiWare.CommandLine.Abstractions.Usage.IConsole.ForegroundColor">
+            <summary>
+            <inheritdoc cref="P:System.Console.ForegroundColor"/>
+            </summary>
+        </member>
+        <member name="M:MatthiWare.CommandLine.Abstractions.Usage.IConsole.ResetColor">
+            <summary>
+            <inheritdoc cref="M:System.Console.ResetColor"/>
             </summary>
         </member>
         <member name="T:MatthiWare.CommandLine.Abstractions.Usage.IEnvironmentVariablesService">
@@ -1738,6 +1770,24 @@
         <member name="P:MatthiWare.CommandLine.Core.Usage.EnvironmentVariableService.NoColorRequested">
             <inheritdoc/>
         </member>
+        <member name="T:MatthiWare.CommandLine.Core.Usage.SystemConsole">
+            <inheritdoc/>
+        </member>
+        <member name="P:MatthiWare.CommandLine.Core.Usage.SystemConsole.ForegroundColor">
+            <inheritdoc/>
+        </member>
+        <member name="M:MatthiWare.CommandLine.Core.Usage.SystemConsole.ErrorWriteLine(System.String)">
+            <inheritdoc/>
+        </member>
+        <member name="M:MatthiWare.CommandLine.Core.Usage.SystemConsole.ResetColor">
+            <inheritdoc/>
+        </member>
+        <member name="M:MatthiWare.CommandLine.Core.Usage.SystemConsole.WriteLine(System.String)">
+            <inheritdoc/>
+        </member>
+        <member name="M:MatthiWare.CommandLine.Core.Usage.SystemConsole.WriteLine">
+            <inheritdoc/>
+        </member>
         <member name="T:MatthiWare.CommandLine.Core.Usage.UsageBuilder">
             <inheritdoc/>
         </member>
@@ -1771,19 +1821,27 @@
         <member name="M:MatthiWare.CommandLine.Core.Usage.UsageBuilder.AddErrors(System.Collections.Generic.IReadOnlyCollection{System.Exception})">
             <inheritdoc/>
         </member>
+        <member name="M:MatthiWare.CommandLine.Core.Usage.UsageBuilder.AddSuggestionHeader(System.String)">
+            <inheritdoc/>
+        </member>
+        <member name="M:MatthiWare.CommandLine.Core.Usage.UsageBuilder.AddSuggestion(System.String)">
+            <inheritdoc/>
+        </member>
         <member name="T:MatthiWare.CommandLine.Core.Usage.UsagePrinter">
             <inheritdoc/>
         </member>
         <member name="P:MatthiWare.CommandLine.Core.Usage.UsagePrinter.Builder">
             <inheritdoc/>
         </member>
-        <member name="M:MatthiWare.CommandLine.Core.Usage.UsagePrinter.#ctor(MatthiWare.CommandLine.Abstractions.Command.ICommandLineCommandContainer,MatthiWare.CommandLine.Abstractions.Usage.IUsageBuilder,MatthiWare.CommandLine.Abstractions.Usage.IEnvironmentVariablesService,MatthiWare.CommandLine.Abstractions.Usage.ISuggestionProvider)">
+        <member name="M:MatthiWare.CommandLine.Core.Usage.UsagePrinter.#ctor(MatthiWare.CommandLine.Abstractions.Usage.IConsole,MatthiWare.CommandLine.Abstractions.Command.ICommandLineCommandContainer,MatthiWare.CommandLine.Abstractions.Usage.IUsageBuilder,MatthiWare.CommandLine.Abstractions.Usage.IEnvironmentVariablesService,MatthiWare.CommandLine.Abstractions.Usage.ISuggestionProvider)">
             <summary>
             Creates a new CLI output usage printer
             </summary>
+            <param name="console"></param>
             <param name="container"></param>
             <param name="builder"></param>
             <param name="environmentVariablesService"></param>
+            <param name="suggestionProvider"></param>
         </member>
         <member name="M:MatthiWare.CommandLine.Core.Usage.UsagePrinter.PrintErrors(System.Collections.Generic.IReadOnlyCollection{System.Exception})">
             <inheritdoc/>
@@ -1804,6 +1862,9 @@
             <inheritdoc/>
         </member>
         <member name="M:MatthiWare.CommandLine.Core.Usage.UsagePrinter.PrintUsage(MatthiWare.CommandLine.Abstractions.ICommandLineOption)">
+            <inheritdoc/>
+        </member>
+        <member name="M:MatthiWare.CommandLine.Core.Usage.UsagePrinter.PrintSuggestion(MatthiWare.CommandLine.Abstractions.Parsing.UnusedArgumentModel)">
             <inheritdoc/>
         </member>
         <member name="T:MatthiWare.CommandLine.Core.Utils.ExtensionMethods">

--- a/CommandLineParser/CommandLineParserOptions.cs
+++ b/CommandLineParser/CommandLineParserOptions.cs
@@ -30,7 +30,7 @@ namespace MatthiWare.CommandLine
         /// <summary>
         /// Help option name. 
         /// Accepts both formatted and unformatted help name. 
-        /// If the name is a single string it will use the <see cref="PrefixLongOption"/>
+        /// If the name is a single string it will use the <see cref="HelpOptionName"/>
         /// If the name is split for example h|help it will use the following format <![CDATA[<shortOption>|<longOption>]]>
         /// </summary>
         public string HelpOptionName { get; set; } = "h|help";
@@ -53,11 +53,6 @@ namespace MatthiWare.CommandLine
 
         internal (string shortOption, string longOption) GetConfiguredHelpOption()
         {
-            if (!EnableHelpOption)
-            {
-                return (null, null);
-            }
-
             var tokens = HelpOptionName.Split('|');
 
             string shortResult;

--- a/CommandLineParser/CommandLineParser`TOption.cs
+++ b/CommandLineParser/CommandLineParser`TOption.cs
@@ -213,7 +213,7 @@ namespace MatthiWare.CommandLine
 
             await AutoExecuteCommandsAsync(result, cancellationToken);
 
-            AutoPrintUsageAndErrors(result, args.Length == 0);
+            AutoPrintUsageAndErrors(result, args.Length == 0 || args.Length == argumentManager.UnusedArguments.Count);
 
             return result;
         }
@@ -260,7 +260,7 @@ namespace MatthiWare.CommandLine
                 return;
             }
 
-            if (noArgsSupplied && (Options.Any(opt => !opt.HasDefault) || Commands.Any(cmd => cmd.IsRequired)))
+            if (noArgsSupplied && (Options.Any(opt => !opt.HasDefault) || result.CommandResults.Any(cmd => !cmd.Found)))
             {
                 PrintHelp();
             }

--- a/CommandLineParser/CommandLineParser`TOption.cs
+++ b/CommandLineParser/CommandLineParser`TOption.cs
@@ -24,6 +24,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
 [assembly: InternalsVisibleTo("CommandLineParser.Tests")]
+[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]
 
 namespace MatthiWare.CommandLine
 {
@@ -213,7 +214,7 @@ namespace MatthiWare.CommandLine
 
             await AutoExecuteCommandsAsync(result, cancellationToken);
 
-            AutoPrintUsageAndErrors(result, args.Length == 0 || args.Length == argumentManager.UnusedArguments.Count);
+            AutoPrintUsageAndErrors(result, args.Length == 0);
 
             return result;
         }
@@ -267,6 +268,11 @@ namespace MatthiWare.CommandLine
             {
                 PrintHelpRequestedForArgument(result.HelpRequestedFor);
             }
+            else if (!noArgsSupplied && argumentManager.UnusedArguments.Count > 0)
+            {
+                PrintHelp();
+                PrintSuggestionsIfAny();
+            }
             else if (result.HasErrors)
             {
                 PrintErrors(result.Errors);
@@ -296,6 +302,8 @@ namespace MatthiWare.CommandLine
         }
 
         private void PrintHelp() => Printer.PrintUsage();
+
+        private void PrintSuggestionsIfAny() => Printer.PrintSuggestion(argumentManager.UnusedArguments.First());
 
         private async Task AutoExecuteCommandsAsync(ParseResult<TOption> result, CancellationToken cancellationToken)
         {

--- a/CommandLineParser/Core/DependencyInjectionExtensions.cs
+++ b/CommandLineParser/Core/DependencyInjectionExtensions.cs
@@ -108,6 +108,7 @@ namespace MatthiWare.CommandLine.Core
         {
             services.TryAddScoped<IUsageBuilder, UsageBuilder>();
             services.TryAddScoped<IUsagePrinter, UsagePrinter>();
+            services.TryAddScoped<IConsole, SystemConsole>();
 
             return services;
         }

--- a/CommandLineParser/Core/DependencyInjectionExtensions.cs
+++ b/CommandLineParser/Core/DependencyInjectionExtensions.cs
@@ -46,7 +46,8 @@ namespace MatthiWare.CommandLine.Core
                 .AddCommandDiscoverer()
                 .AddEnvironmentVariables()
                 .AddDefaultLogger()
-                .AddModelInitializer();
+                .AddModelInitializer()
+                .AddSuggestionProvider();
         }
 
         internal static IServiceCollection AddArgumentManager(this IServiceCollection services)
@@ -75,6 +76,13 @@ namespace MatthiWare.CommandLine.Core
         private static IServiceCollection AddValidatorContainer(this IServiceCollection services)
         {
             services.AddSingleton<IValidatorsContainer, ValidatorsContainer>();
+
+            return services;
+        }
+
+        private static IServiceCollection AddSuggestionProvider(this IServiceCollection services)
+        {
+            services.AddSingleton<ISuggestionProvider, DamerauLevenshteinSuggestionProvider>();
 
             return services;
         }

--- a/CommandLineParser/Core/Parsing/ArgumentManager.cs
+++ b/CommandLineParser/Core/Parsing/ArgumentManager.cs
@@ -101,6 +101,11 @@ namespace MatthiWare.CommandLine.Core.Parsing
 
         private void AddUnprocessedArgument(ArgumentRecord rec)
         {
+            //if (isFirstArgument)
+            //{
+            //    return;
+            //}
+
             var arg = CurrentContext.CurrentOption != null ? (IArgument)CurrentContext.CurrentOption : (IArgument)CurrentContext.CurrentCommand;
             var item = new UnusedArgumentModel(rec.RawData, arg);
 
@@ -281,10 +286,10 @@ namespace MatthiWare.CommandLine.Core.Parsing
 
             context = CurrentContext;
 
-            if (isFirstArgument)
-            {
-                return false;
-            }
+            //if (isFirstArgument)
+            //{
+            //    return false;
+            //}
 
             while (context != null)
             {

--- a/CommandLineParser/Core/Parsing/ArgumentManager.cs
+++ b/CommandLineParser/Core/Parsing/ArgumentManager.cs
@@ -20,8 +20,8 @@ namespace MatthiWare.CommandLine.Core.Parsing
         private IEnumerator<ArgumentRecord> enumerator;
         private readonly Dictionary<IArgument, ArgumentModel> results = new Dictionary<IArgument, ArgumentModel>();
         private readonly List<UnusedArgumentModel> unusedArguments = new List<UnusedArgumentModel>();
-        private ProcessingContext CurrentContext { get; set; }
-        private bool isFirstArgument = true;
+        private ProcessingContext CurrentContext;
+        private bool isFirstUnprocessedArgument = true;
 
         /// <inheritdoc/>
         public IReadOnlyList<UnusedArgumentModel> UnusedArguments => unusedArguments;
@@ -46,7 +46,7 @@ namespace MatthiWare.CommandLine.Core.Parsing
             enumerator = new ArgumentRecordEnumerator(options, arguments);
             CurrentContext = new ProcessingContext(null, commandContainer, logger);
 
-            isFirstArgument = true;
+            isFirstUnprocessedArgument = true;
 
             try
             {
@@ -58,8 +58,6 @@ namespace MatthiWare.CommandLine.Core.Parsing
                     {
                         AddUnprocessedArgument(enumerator.Current);
                     }
-
-                    isFirstArgument = false;
                 }
             }
             catch (InvalidOperationException invalidOpException)
@@ -120,11 +118,6 @@ namespace MatthiWare.CommandLine.Core.Parsing
 
         private void AddUnprocessedArgument(ArgumentRecord rec)
         {
-            if (isFirstArgument)
-            {
-                //throw new Exception("NOT FOUND OOPSIE");
-            }
-
             var arg = CurrentContext.CurrentOption != null ? (IArgument)CurrentContext.CurrentOption : (IArgument)CurrentContext.CurrentCommand;
             var item = new UnusedArgumentModel(rec.RawData, arg);
 

--- a/CommandLineParser/Core/Usage/DamerauLevenshteinSuggestionProvider.cs
+++ b/CommandLineParser/Core/Usage/DamerauLevenshteinSuggestionProvider.cs
@@ -1,0 +1,24 @@
+﻿using MatthiWare.CommandLine.Abstractions.Command;
+using MatthiWare.CommandLine.Abstractions.Usage;
+using Microsoft.Extensions.Logging;
+using System.Collections.Generic;
+
+namespace MatthiWare.CommandLine.Core.Usage
+{
+    internal class DamerauLevenshteinSuggestionProvider : ISuggestionProvider
+    {
+        private readonly ILogger<CommandLineParser> logger;
+        private readonly ICommandLineCommandContainer container;
+
+        public DamerauLevenshteinSuggestionProvider(ILogger<CommandLineParser> logger, ICommandLineCommandContainer container)
+        {
+            this.logger = logger ?? throw new System.ArgumentNullException(nameof(logger));
+            this.container = container ?? throw new System.ArgumentNullException(nameof(container));
+        }
+
+        public IEnumerable<string> GetSuggestions(string input)
+        {
+            throw new System.NotImplementedException();
+        }
+    }
+}

--- a/CommandLineParser/Core/Usage/DamerauLevenshteinSuggestionProvider.cs
+++ b/CommandLineParser/Core/Usage/DamerauLevenshteinSuggestionProvider.cs
@@ -1,24 +1,159 @@
 ﻿using MatthiWare.CommandLine.Abstractions.Command;
 using MatthiWare.CommandLine.Abstractions.Usage;
 using Microsoft.Extensions.Logging;
+using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace MatthiWare.CommandLine.Core.Usage
 {
     internal class DamerauLevenshteinSuggestionProvider : ISuggestionProvider
     {
-        private readonly ILogger<CommandLineParser> logger;
-        private readonly ICommandLineCommandContainer container;
+        private const double threshold = 0.33;
 
-        public DamerauLevenshteinSuggestionProvider(ILogger<CommandLineParser> logger, ICommandLineCommandContainer container)
+        public IEnumerable<string> GetSuggestions(string input, ICommandLineCommandContainer command)
         {
-            this.logger = logger ?? throw new System.ArgumentNullException(nameof(logger));
-            this.container = container ?? throw new System.ArgumentNullException(nameof(container));
+            var suggestions = GetAvailableSuggestions(command);
+
+            return GetBestMatchesOrdered(suggestions, input);
         }
 
-        public IEnumerable<string> GetSuggestions(string input)
+        private IEnumerable<string> GetAvailableSuggestions(ICommandLineCommandContainer commandContext)
         {
-            throw new System.NotImplementedException();
+            foreach (var cmd in commandContext.Commands)
+            {
+                yield return cmd.Name;
+            }
+
+            foreach (var option in commandContext.Options)
+            {
+                if (option.HasShortName)
+                {
+                    yield return option.ShortName;
+                }
+
+                if (option.HasLongName)
+                {
+                    yield return option.LongName;
+                }
+            }
+        }
+
+        private IEnumerable<string> GetBestMatchesOrdered(IEnumerable<string> suggestions, string input)
+        {
+            int inputLength = input.Length;
+
+            return suggestions
+                .Select(suggestion =>
+                {
+                    var dist = FindDistance(input, suggestion);
+                    var len = Math.Max(inputLength, suggestion.Length);
+                    var normalized = NormalizeDistance(dist, len);
+                    return (suggestion, normalized);
+                })
+                .Where(_ => _.normalized >= threshold)
+                .OrderByDescending(_ => _.normalized)
+                .Select(_ => _.suggestion);
+        }
+
+        private double NormalizeDistance(int distance, int length)
+        {
+            if (length == 0)
+            {
+                return 0;
+            }
+
+            if (distance == 0)
+            {
+                return 1;
+            }
+
+            return 1.0d - distance / (double)length;
+        }
+
+        /// <summary>
+        /// Damerau-Levenshtein Distance algorithm implemented using Optimal String Alignment Distance. 
+        /// </summary>
+        /// <remarks>
+        /// https://en.wikipedia.org/wiki/Damerau%E2%80%93Levenshtein_distance
+        /// </remarks>
+        /// <param name="input">string A</param>
+        /// <param name="suggestion">string B</param>
+        /// <returns>Damerau-Levenshtein Distance</returns>
+        internal int FindDistance(in string input, in string suggestion)
+        {
+            // Short circuit so we don't waste cpu time
+            if (input == suggestion)
+            {
+                return 0;
+            }
+
+            if (string.IsNullOrEmpty(input))
+            {
+                return !string.IsNullOrEmpty(suggestion) ? suggestion.Length : 0;
+            }
+
+            if (string.IsNullOrEmpty(suggestion))
+            {
+                return !string.IsNullOrEmpty(input) ? input.Length : 0;
+            }
+
+            var inputLength = input.Length;
+            var suggestionLength = suggestion.Length;
+
+            var matrix = CreateMatrix(in inputLength, in suggestionLength);
+
+            for (var i = 1; i <= inputLength; i++)
+            {
+                for (var j = 1; j <= suggestionLength; j++)
+                {
+                    CalculateCost(in i, in j, in matrix, in input, in suggestion);
+                }
+            }
+
+            return matrix[inputLength, suggestionLength];
+        }
+
+        private void CalculateCost(in int i, in int j, in int[,] matrix, in string input, in string suggestion)
+        {
+            var cost = input[i - 1] == suggestion[j - 1] ? 0 : 1;
+
+            var changes = new[]
+            {
+                //Insertion
+                matrix[i, j - 1] + 1,
+                //Deletion
+                matrix[i - 1, j] + 1,
+                //Substitution
+                matrix[i - 1, j - 1] + cost
+            };
+
+            var distance = changes.Min();
+
+            if (i > 1 && j > 1 && input[i - 1] == suggestion[j - 2] && input[i - 2] == suggestion[j - 1])
+            {
+                // Transposition of two successive symbols
+                distance = Math.Min(distance, matrix[i - 2, j - 2] + cost);
+            }
+
+            matrix[i, j] = distance;
+        }
+
+        private int[,] CreateMatrix(in int sizeA, in int sizeB)
+        {
+            var matrix = new int[sizeA + 1, sizeB + 1];
+
+            for (var i = 0; i <= sizeA; i++)
+            {
+                matrix[i, 0] = i;
+            }
+
+            for (var j = 0; j <= sizeB; j++)
+            {
+                matrix[0, j] = j;
+            }
+
+            return matrix;
         }
     }
 }

--- a/CommandLineParser/Core/Usage/DamerauLevenshteinSuggestionProvider.cs
+++ b/CommandLineParser/Core/Usage/DamerauLevenshteinSuggestionProvider.cs
@@ -13,6 +13,11 @@ namespace MatthiWare.CommandLine.Core.Usage
 
         public IEnumerable<string> GetSuggestions(string input, ICommandLineCommandContainer command)
         {
+            if (command is null)
+            {
+                return Array.Empty<string>();
+            }
+
             var suggestions = GetAvailableSuggestions(command);
 
             return GetBestMatchesOrdered(suggestions, input);

--- a/CommandLineParser/Core/Usage/SystemConsole.cs
+++ b/CommandLineParser/Core/Usage/SystemConsole.cs
@@ -1,0 +1,25 @@
+﻿using MatthiWare.CommandLine.Abstractions.Usage;
+using System;
+
+namespace MatthiWare.CommandLine.Core.Usage
+{
+    /// <inheritdoc/>
+    public class SystemConsole : IConsole
+    {
+        /// <inheritdoc/>
+        public ConsoleColor ForegroundColor 
+        { 
+            get => Console.ForegroundColor; 
+            set => Console.ForegroundColor = value;
+        }
+
+        /// <inheritdoc/>
+        public void ErrorWriteLine(string text) => Console.Error.WriteLine(text);
+
+        /// <inheritdoc/>
+        public void ResetColor() => Console.ResetColor();
+
+        /// <inheritdoc/>
+        public void WriteLine(string text) => Console.WriteLine(text);
+    }
+}

--- a/CommandLineParser/Core/Usage/SystemConsole.cs
+++ b/CommandLineParser/Core/Usage/SystemConsole.cs
@@ -21,5 +21,8 @@ namespace MatthiWare.CommandLine.Core.Usage
 
         /// <inheritdoc/>
         public void WriteLine(string text) => Console.WriteLine(text);
+
+        /// <inheritdoc/>
+        public void WriteLine() => Console.WriteLine();
     }
 }

--- a/CommandLineParser/Core/Usage/UsageBuilder.cs
+++ b/CommandLineParser/Core/Usage/UsageBuilder.cs
@@ -120,6 +120,7 @@ namespace MatthiWare.CommandLine.Core.Usage
             }
         }
 
+        /// <inheritdoc/>
         public void AddSuggestionHeader(string inputKey)
         {
             stringBuilder.AppendLine($"'{inputKey}' is not recognized as a valid command or option.");
@@ -127,9 +128,10 @@ namespace MatthiWare.CommandLine.Core.Usage
             stringBuilder.AppendLine("Did you mean: ");
         }
 
+        /// <inheritdoc/>
         public void AddSuggestion(string suggestion)
         {
-            stringBuilder.Append($"\t{suggestion}");
+            stringBuilder.AppendLine($"\t{suggestion}"); 
         }
     }
 }

--- a/CommandLineParser/Core/Usage/UsageBuilder.cs
+++ b/CommandLineParser/Core/Usage/UsageBuilder.cs
@@ -119,5 +119,17 @@ namespace MatthiWare.CommandLine.Core.Usage
                 stringBuilder.AppendLine(error.Message);
             }
         }
+
+        public void AddSuggestionHeader(string inputKey)
+        {
+            stringBuilder.AppendLine($"'{inputKey}' is not recognized as a valid command or option.");
+            stringBuilder.AppendLine();
+            stringBuilder.AppendLine("Did you mean: ");
+        }
+
+        public void AddSuggestion(string suggestion)
+        {
+            stringBuilder.Append($"\t{suggestion}");
+        }
     }
 }

--- a/CommandLineParser/Core/Usage/UsagePrinter.cs
+++ b/CommandLineParser/Core/Usage/UsagePrinter.cs
@@ -11,6 +11,7 @@ namespace MatthiWare.CommandLine.Core.Usage
     /// <inheritdoc/>
     public class UsagePrinter : IUsagePrinter
     {
+        private readonly IConsole console;
         private readonly IEnvironmentVariablesService environmentVariablesService;
         private readonly ISuggestionProvider suggestionProvider;
 
@@ -19,16 +20,17 @@ namespace MatthiWare.CommandLine.Core.Usage
         /// <inheritdoc/>
         public IUsageBuilder Builder { get; }
 
-        internal ConsoleColor m_currentConsoleColor = ConsoleColor.Gray;
-
         /// <summary>
         /// Creates a new CLI output usage printer
         /// </summary>
+        /// <param name="console"></param>
         /// <param name="container"></param>
         /// <param name="builder"></param>
         /// <param name="environmentVariablesService"></param>
-        public UsagePrinter(ICommandLineCommandContainer container, IUsageBuilder builder, IEnvironmentVariablesService environmentVariablesService, ISuggestionProvider suggestionProvider)
+        /// <param name="suggestionProvider"></param>
+        public UsagePrinter(IConsole console, ICommandLineCommandContainer container, IUsageBuilder builder, IEnvironmentVariablesService environmentVariablesService, ISuggestionProvider suggestionProvider)
         {
+            this.console = console ?? throw new ArgumentNullException(nameof(console));
             Container = container ?? throw new ArgumentNullException(nameof(container));
             Builder = builder ?? throw new ArgumentNullException(nameof(builder));
             this.environmentVariablesService = environmentVariablesService ?? throw new ArgumentNullException(nameof(environmentVariablesService));
@@ -42,42 +44,40 @@ namespace MatthiWare.CommandLine.Core.Usage
 
             if (canOutputColor)
             {
-                m_currentConsoleColor = ConsoleColor.Red;
-                Console.ForegroundColor = ConsoleColor.Red;
+                console = ConsoleColor.Red;
             }
 
             Builder.AddErrors(errors);
 
-            Console.Error.WriteLine(Builder.Build());
+            console.ErrorWriteLine(Builder.Build());
 
             if (canOutputColor)
             {
-                m_currentConsoleColor = ConsoleColor.Gray;
-                Console.ResetColor();
+                console.ResetColor();
             }
 
-            Console.WriteLine();
+            console.WriteLine();
         }
 
         /// <inheritdoc/>
         public virtual void PrintCommandUsage(ICommandLineCommand command)
         {
             Builder.AddCommand(command.Name, command);
-            Console.WriteLine(Builder.Build());
+            console.WriteLine(Builder.Build());
         }
 
         /// <inheritdoc/>
         public virtual void PrintOptionUsage(ICommandLineOption option)
         {
             Builder.AddOption(option);
-            Console.WriteLine(Builder.Build());
+            console.WriteLine(Builder.Build());
         }
 
         /// <inheritdoc/>
         public virtual void PrintUsage()
         {
             Builder.AddCommand(string.Empty, Container);
-            Console.WriteLine(Builder.Build());
+            console.WriteLine(Builder.Build());
         }
 
         /// <inheritdoc/>
@@ -105,6 +105,7 @@ namespace MatthiWare.CommandLine.Core.Usage
         public virtual void PrintUsage(ICommandLineOption option)
             => PrintOptionUsage(option);
 
+        /// <inheritdoc/>
         public void PrintSuggestion(UnusedArgumentModel model)
         {
             var suggestions = suggestionProvider.GetSuggestions(model.Key, model.Argument as ICommandLineCommandContainer);
@@ -120,6 +121,8 @@ namespace MatthiWare.CommandLine.Core.Usage
             {
                 Builder.AddSuggestion(suggestion);
             }
+
+            console.WriteLine(Builder.Build());
         }
     }
 }

--- a/CommandLineParser/Core/Usage/UsagePrinter.cs
+++ b/CommandLineParser/Core/Usage/UsagePrinter.cs
@@ -1,8 +1,10 @@
 ﻿using MatthiWare.CommandLine.Abstractions;
 using MatthiWare.CommandLine.Abstractions.Command;
+using MatthiWare.CommandLine.Abstractions.Parsing;
 using MatthiWare.CommandLine.Abstractions.Usage;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace MatthiWare.CommandLine.Core.Usage
 {
@@ -10,6 +12,7 @@ namespace MatthiWare.CommandLine.Core.Usage
     public class UsagePrinter : IUsagePrinter
     {
         private readonly IEnvironmentVariablesService environmentVariablesService;
+        private readonly ISuggestionProvider suggestionProvider;
 
         protected ICommandLineCommandContainer Container { get; }
 
@@ -24,11 +27,12 @@ namespace MatthiWare.CommandLine.Core.Usage
         /// <param name="container"></param>
         /// <param name="builder"></param>
         /// <param name="environmentVariablesService"></param>
-        public UsagePrinter(ICommandLineCommandContainer container, IUsageBuilder builder, IEnvironmentVariablesService environmentVariablesService)
+        public UsagePrinter(ICommandLineCommandContainer container, IUsageBuilder builder, IEnvironmentVariablesService environmentVariablesService, ISuggestionProvider suggestionProvider)
         {
             Container = container ?? throw new ArgumentNullException(nameof(container));
             Builder = builder ?? throw new ArgumentNullException(nameof(builder));
             this.environmentVariablesService = environmentVariablesService ?? throw new ArgumentNullException(nameof(environmentVariablesService));
+            this.suggestionProvider = suggestionProvider ?? throw new ArgumentNullException(nameof(suggestionProvider));
         }
 
         /// <inheritdoc/>
@@ -100,5 +104,22 @@ namespace MatthiWare.CommandLine.Core.Usage
         /// <inheritdoc/>
         public virtual void PrintUsage(ICommandLineOption option)
             => PrintOptionUsage(option);
+
+        public void PrintSuggestion(UnusedArgumentModel model)
+        {
+            var suggestions = suggestionProvider.GetSuggestions(model.Key, model.Argument as ICommandLineCommandContainer);
+
+            if (!suggestions.Any())
+            {
+                return;
+            }
+
+            Builder.AddSuggestion(model.Key);
+
+            foreach (var suggestion in suggestions)
+            {
+                Builder.AddSuggestion(suggestion);
+            }
+        }
     }
 }

--- a/CommandLineParser/Core/Usage/UsagePrinter.cs
+++ b/CommandLineParser/Core/Usage/UsagePrinter.cs
@@ -44,7 +44,7 @@ namespace MatthiWare.CommandLine.Core.Usage
 
             if (canOutputColor)
             {
-                console = ConsoleColor.Red;
+                console.ForegroundColor = ConsoleColor.Red;
             }
 
             Builder.AddErrors(errors);
@@ -115,12 +115,9 @@ namespace MatthiWare.CommandLine.Core.Usage
                 return;
             }
 
-            Builder.AddSuggestion(model.Key);
+            Builder.AddSuggestionHeader(model.Key);
 
-            foreach (var suggestion in suggestions)
-            {
-                Builder.AddSuggestion(suggestion);
-            }
+            Builder.AddSuggestion(suggestions.First());
 
             console.WriteLine(Builder.Build());
         }

--- a/Extensions/Tests/FluentValidationsExtensions.Tests/FluentValidationsTests.cs
+++ b/Extensions/Tests/FluentValidationsExtensions.Tests/FluentValidationsTests.cs
@@ -35,7 +35,7 @@ namespace FluentValidationsExtensions.Tests
 
             parser.RegisterCommand<CommandWithModel<FirstModel, EmailModel>, EmailModel>();
 
-            var result = parser.Parse(new string[] { "app.exe", "-f", "JamesJames1", "-l", "Bond123456789", "cmd", "-e", "jane.doe@provider.com", "-i", "50" });
+            var result = parser.Parse(new string[] { "-f", "JamesJames1", "-l", "Bond123456789", "cmd", "-e", "jane.doe@provider.com", "-i", "50" });
 
             result.AssertNoErrors();
         }
@@ -56,7 +56,7 @@ namespace FluentValidationsExtensions.Tests
 
             parser.RegisterCommand<CommandWithModel<FirstModel, EmailModel>, EmailModel>();
 
-            var result = parser.Parse(new string[] { "app.exe", "-f", "James", "-l", "Bond", "cmd", "-e", "jane.doe@provider.com", "-i", "50" });
+            var result = parser.Parse(new string[] { "-f", "James", "-l", "Bond", "cmd", "-e", "jane.doe@provider.com", "-i", "50" });
 
             Assert.True(result.AssertNoErrors(false));
         }
@@ -77,7 +77,7 @@ namespace FluentValidationsExtensions.Tests
 
             parser.RegisterCommand<CommandWithModel<FirstModel, EmailModel>, EmailModel>();
 
-            var result = parser.Parse(new string[] { "app.exe", "-f", "JamesJames1", "-l", "BondBond1231456", "cmd", "-e", "jane.doe@provider.com", "-i", "0" });
+            var result = parser.Parse(new string[] { "-f", "JamesJames1", "-l", "BondBond1231456", "cmd", "-e", "jane.doe@provider.com", "-i", "0" });
 
             Assert.True(result.AssertNoErrors(false));
         }


### PR DESCRIPTION
Fixes #90 

Example:
```
❯ D:\Source\Repos\CommandLineParser\SampleApp\bin\Debug\netcoreapp3.1\SampleApp.exe throwww
Input arguments: throwww


Usage: Sample App [options] [commands]

Options:
  -i|--int            Description for -i option, needs an integer.
  -s|--string         Description for -s option, needs a string.
  -b|--bool           Description for -b option, needs a boolean.
  -d|--double         Description for -d option, needs a double.

Commands:
  di                  Example using Dependency Injection
  start               Start the server command.
  throw               Throws an error when executed

'throwww' is not recognized as a valid command or option.

Did you mean:
        throw

Press any key to exit
```
