### PR TITLE
Empty exception messages when command has missing required options

### DIFF
--- a/CommandLineParser.Tests/Exceptions/ExceptionsTest.cs
+++ b/CommandLineParser.Tests/Exceptions/ExceptionsTest.cs
@@ -1,6 +1,9 @@
 ﻿using MatthiWare.CommandLine.Abstractions.Command;
 using MatthiWare.CommandLine.Core.Attributes;
 using MatthiWare.CommandLine.Core.Exceptions;
+using Moq;
+using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
@@ -128,6 +131,46 @@ namespace MatthiWare.CommandLine.Tests.Exceptions
             Assert.IsType<CommandParseException>(result.Errors.First());
 
             Assert.Same(parser.Commands.First(), result.Errors.Cast<CommandParseException>().First().Command);
+        }
+
+        [Fact]
+        public void CommandParseException_Should_Contain_Correct_Message_Single()
+        {
+            var cmdMock = new Mock<ICommandLineCommand>();
+            cmdMock.SetupGet(_ => _.Name).Returns("test");
+
+            var exceptionList = new List<Exception>
+            {
+                new Exception("msg1")
+            };
+
+            var parseException = new CommandParseException(cmdMock.Object, exceptionList.AsReadOnly());
+            var msg = parseException.Message;
+            var expected = @"Unable to parse command 'test' because msg1";
+
+            Assert.Equal(expected, msg);
+        }
+
+        [Fact]
+        public void CommandParseException_Should_Contain_Correct_Message_Multiple()
+        {
+            var cmdMock = new Mock<ICommandLineCommand>();
+            cmdMock.SetupGet(_ => _.Name).Returns("test");
+
+            var exceptionList = new List<Exception>
+            {
+                new Exception("msg1"),
+                new Exception("msg2")
+            };
+
+            var parseException = new CommandParseException(cmdMock.Object, exceptionList.AsReadOnly());
+            var msg = parseException.Message;
+            var expected = @"Unable to parse command 'test' because 2 errors occured
+ - msg1
+ - msg2
+";
+
+            Assert.Equal(expected, msg);
         }
 
         [Fact]

--- a/CommandLineParser/Abstractions/Parsing/IArgumentManager.cs
+++ b/CommandLineParser/Abstractions/Parsing/IArgumentManager.cs
@@ -1,4 +1,5 @@
 ﻿using MatthiWare.CommandLine.Abstractions.Models;
+using MatthiWare.CommandLine.Abstractions.Usage;
 using System;
 using System.Collections.Generic;
 
@@ -10,9 +11,21 @@ namespace MatthiWare.CommandLine.Abstractions.Parsing
     public interface IArgumentManager
     {
         /// <summary>
-        /// Returns a read-only list of unused arguments
+        /// Returns a read-only list of arguments that never got processed because they appeared after the <see cref="CommandLineParserOptions.StopParsingAfter"/> flag.
+        /// </summary>
+        IReadOnlyList<UnusedArgumentModel> UnprocessedArguments { get; }
+
+        /// <summary>
+        /// Returns a read-only list of unused arguments. 
+        /// In most cases this will be mistyped arguments that are not mapped to the actual option/command names.
+        /// You can pass these arguments inside the <see cref="IUsagePrinter.PrintSuggestion(UnusedArgumentModel)"/> to get a suggestion of what could be the correct argument.
         /// </summary>
         IReadOnlyList<UnusedArgumentModel> UnusedArguments { get; }
+
+        /// <summary>
+        /// Returns if the <see cref="CommandLineParserOptions.StopParsingAfter"/> flag was found. 
+        /// </summary>
+        bool StopParsingFlagSpecified { get; }
 
         /// <summary>
         /// Tries to get the arguments associated to the current option

--- a/CommandLineParser/Abstractions/Usage/IUsagePrinter.cs
+++ b/CommandLineParser/Abstractions/Usage/IUsagePrinter.cs
@@ -25,8 +25,8 @@ namespace MatthiWare.CommandLine.Abstractions.Usage
         /// Print an argument
         /// </summary>
         /// <param name="argument">The given argument</param>
-        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use PrintCommandUsage or PrintOptionUsage instead")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         void PrintUsage(IArgument argument);
 
         /// <summary>
@@ -63,6 +63,11 @@ namespace MatthiWare.CommandLine.Abstractions.Usage
         /// <param name="errors">list of errors</param>
         void PrintErrors(IReadOnlyCollection<Exception> errors);
 
-        void PrintSuggestion(UnusedArgumentModel model);
+        /// <summary>
+        /// Prints suggestions based on the input arguments
+        /// </summary>
+        /// <param name="model">Input model</param>
+        /// <returns>True if a suggestion was found and printed, otherwise false</returns>
+        bool PrintSuggestion(UnusedArgumentModel model);
     }
 }

--- a/CommandLineParser/CommandLineParser.xml
+++ b/CommandLineParser/CommandLineParser.xml
@@ -767,9 +767,21 @@
             Managers the arguments
             </summary>
         </member>
+        <member name="P:MatthiWare.CommandLine.Abstractions.Parsing.IArgumentManager.UnprocessedArguments">
+            <summary>
+            Returns a read-only list of arguments that never got processed because they appeared after the <see cref="P:MatthiWare.CommandLine.CommandLineParserOptions.StopParsingAfter"/> flag.
+            </summary>
+        </member>
         <member name="P:MatthiWare.CommandLine.Abstractions.Parsing.IArgumentManager.UnusedArguments">
             <summary>
-            Returns a read-only list of unused arguments
+            Returns a read-only list of unused arguments. 
+            In most cases this will be mistyped arguments that are not mapped to the actual option/command names.
+            You can pass these arguments inside the <see cref="M:MatthiWare.CommandLine.Abstractions.Usage.IUsagePrinter.PrintSuggestion(MatthiWare.CommandLine.Abstractions.Parsing.UnusedArgumentModel)"/> to get a suggestion of what could be the correct argument.
+            </summary>
+        </member>
+        <member name="P:MatthiWare.CommandLine.Abstractions.Parsing.IArgumentManager.StopParsingFlagSpecified">
+            <summary>
+            Returns if the <see cref="P:MatthiWare.CommandLine.CommandLineParserOptions.StopParsingAfter"/> flag was found. 
             </summary>
         </member>
         <member name="M:MatthiWare.CommandLine.Abstractions.Parsing.IArgumentManager.TryGetValue(MatthiWare.CommandLine.Abstractions.IArgument,MatthiWare.CommandLine.Abstractions.Models.ArgumentModel@)">
@@ -1083,6 +1095,13 @@
             Print errors
             </summary>
             <param name="errors">list of errors</param>
+        </member>
+        <member name="M:MatthiWare.CommandLine.Abstractions.Usage.IUsagePrinter.PrintSuggestion(MatthiWare.CommandLine.Abstractions.Parsing.UnusedArgumentModel)">
+            <summary>
+            Prints suggestions based on the input arguments
+            </summary>
+            <param name="model">Input model</param>
+            <returns>True if a suggestion was found and printed, otherwise false</returns>
         </member>
         <member name="T:MatthiWare.CommandLine.Abstractions.Validations.IValidator">
             <summary>
@@ -1644,6 +1663,12 @@
             <inheritdoc/>
         </member>
         <member name="P:MatthiWare.CommandLine.Core.Parsing.ArgumentManager.UnusedArguments">
+            <inheritdoc/>
+        </member>
+        <member name="P:MatthiWare.CommandLine.Core.Parsing.ArgumentManager.UnprocessedArguments">
+            <inheritdoc/>
+        </member>
+        <member name="P:MatthiWare.CommandLine.Core.Parsing.ArgumentManager.StopParsingFlagSpecified">
             <inheritdoc/>
         </member>
         <member name="M:MatthiWare.CommandLine.Core.Parsing.ArgumentManager.TryGetValue(MatthiWare.CommandLine.Abstractions.IArgument,MatthiWare.CommandLine.Abstractions.Models.ArgumentModel@)">

--- a/CommandLineParser/Core/Exceptions/CommandParseException.cs
+++ b/CommandLineParser/Core/Exceptions/CommandParseException.cs
@@ -38,7 +38,7 @@ namespace MatthiWare.CommandLine.Core.Exceptions
         }
 
         private static string CreateSingleExceptionMessage(ICommandLineCommand command, Exception exception)
-            => $"Unable to parse command '{command.Name}' because {exception.Message}";
+            => $"Unable to parse command '{command.Name}' reason: {exception.Message}";
 
 
         private static string CreateMultipleExceptionsMessage(ICommandLineCommand command, IReadOnlyCollection<Exception> exceptions)

--- a/CommandLineParser/Core/Exceptions/CommandParseException.cs
+++ b/CommandLineParser/Core/Exceptions/CommandParseException.cs
@@ -40,7 +40,6 @@ namespace MatthiWare.CommandLine.Core.Exceptions
         private static string CreateSingleExceptionMessage(ICommandLineCommand command, Exception exception)
             => $"Unable to parse command '{command.Name}' reason: {exception.Message}";
 
-
         private static string CreateMultipleExceptionsMessage(ICommandLineCommand command, IReadOnlyCollection<Exception> exceptions)
         {
             var message = new StringBuilder();

--- a/CommandLineParser/Core/Exceptions/CommandParseException.cs
+++ b/CommandLineParser/Core/Exceptions/CommandParseException.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Text;
 using MatthiWare.CommandLine.Abstractions.Command;
 
 namespace MatthiWare.CommandLine.Core.Exceptions
@@ -20,7 +22,36 @@ namespace MatthiWare.CommandLine.Core.Exceptions
         /// <param name="command">the failed command</param>
         /// <param name="innerExceptions">collection of inner exception</param>
         public CommandParseException(ICommandLineCommand command, IReadOnlyCollection<Exception> innerExceptions)
-            : base(command, "", new AggregateException(innerExceptions))
+            : base(command, CreateMessage(command, innerExceptions), new AggregateException(innerExceptions))
         { }
+
+        private static string CreateMessage(ICommandLineCommand command, IReadOnlyCollection<Exception> exceptions)
+        {
+            if (exceptions.Count > 1)
+            {
+                return CreateMultipleExceptionsMessage(command, exceptions);
+            }
+            else
+            {
+                return CreateSingleExceptionMessage(command, exceptions.First());
+            }
+        }
+
+        private static string CreateSingleExceptionMessage(ICommandLineCommand command, Exception exception)
+            => $"Unable to parse command '{command.Name}' because {exception.Message}";
+
+
+        private static string CreateMultipleExceptionsMessage(ICommandLineCommand command, IReadOnlyCollection<Exception> exceptions)
+        {
+            var message = new StringBuilder();
+            message.AppendLine($"Unable to parse command '{command.Name}' because {exceptions.Count} errors occured");
+
+            foreach (var exception in exceptions)
+            {
+                message.AppendLine($" - {exception.Message}");
+            }
+
+            return message.ToString();
+        }
     }
 }

--- a/CommandLineParser/Core/Usage/UsagePrinter.cs
+++ b/CommandLineParser/Core/Usage/UsagePrinter.cs
@@ -106,13 +106,13 @@ namespace MatthiWare.CommandLine.Core.Usage
             => PrintOptionUsage(option);
 
         /// <inheritdoc/>
-        public void PrintSuggestion(UnusedArgumentModel model)
+        public virtual bool PrintSuggestion(UnusedArgumentModel model)
         {
             var suggestions = suggestionProvider.GetSuggestions(model.Key, model.Argument as ICommandLineCommandContainer);
 
             if (!suggestions.Any())
             {
-                return;
+                return false;
             }
 
             Builder.AddSuggestionHeader(model.Key);
@@ -120,6 +120,8 @@ namespace MatthiWare.CommandLine.Core.Usage
             Builder.AddSuggestion(suggestions.First());
 
             console.WriteLine(Builder.Build());
+
+            return true;
         }
     }
 }


### PR DESCRIPTION
Fixes #114 by making sure all exceptions have correct messages. 

Usage and suggestion printing has been improved. 