### PR TITLE
Update build.cake to prevent CI from failing

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -1,7 +1,7 @@
 #tool "nuget:?package=xunit.runner.console&version=2.4.1"
-#tool nuget:?package=Codecov
-#addin "nuget:?package=Cake.Codecov&version=0.9.1""
-#addin nuget:?package=Cake.Coverlet
+#tool "nuget:?package=Codecov"
+#addin "nuget:?package=Cake.Codecov&version=0.9.1"
+#addin "nuget:?package=Cake.Coverlet&version=2.5.1"
 ///////////////////////////////////////////////////////////////////////////////
 // ARGUMENTS
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Downgrade to known working version of coverlet.

See: Romanx/Cake.Coverlet#40